### PR TITLE
minor: add support for Jira project key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use the binaries from [the release page](https://github.com/snyk-tech-services/j
 ./snyk-jira-sync-<yourplatform> 
     -orgID=<SNYK_ORG_ID>                    // Can find it under settings
     -token=<API Token>                      // Snyk API Token. Service accounts work.
-    -jiraProjectID=<12345>                  // Jira project ID the tickets will be opened against
+    -jiraProjectKey=<Key>                  // Jira project Key the tickets will be opened against
 ```
 ### Extended options
 ```
@@ -25,6 +25,7 @@ Use the binaries from [the release page](https://github.com/snyk-tech-services/j
     -api=<API endpoint>                                                 // Optional. Set to https://<instance>/api for private instances
     -token=<API Token>                                                  // Snyk API Token. Service accounts work.
     -jiraProjectID=<12345>                                              // Jira project ID the tickets will be opened against
+    -jiraProjectKey=<KEY>                                               // Jira project Key the tickets will be opened against
     -jiraTicketType=<Task|Bug|....>                                     // Optional. Type of ticket to open. Defaults to Bug
     -severity=<critical|high|medium|low>                                // Optional. Severity threshold to open tickets for. Defaults to low.
     -maturityFilter=[mature,proof-of-concept,no-known-exploit,no-data]  // Optional. include only maturity level(s). Separated by commas

--- a/jira_labels_test.go
+++ b/jira_labels_test.go
@@ -42,7 +42,7 @@ func TestOpenJiraTicketWithLabelsFunc(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	numberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "", "Label1,Label2", projectInfo, vulnsForJira, false)
+	numberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "", "Label1,Label2", projectInfo, vulnsForJira, false)
 
 	var mirroredResponse mirroredResponse
 	if err := json.Unmarshal([]byte(jiraResponse), &mirroredResponse); err != nil {
@@ -67,7 +67,7 @@ func TestOpenJiraTicketWithoutLabelsFunc(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	numberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "", "", projectInfo, vulnsForJira, false)
+	numberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "", "", projectInfo, vulnsForJira, false)
 
 	var mirroredResponse mirroredResponse
 	if err := json.Unmarshal([]byte(jiraResponse), &mirroredResponse); err != nil {

--- a/jira_prioritymapping_test.go
+++ b/jira_prioritymapping_test.go
@@ -24,7 +24,7 @@ func TestOpenJiraTicketWithPriorityMappingFunc(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "", "", projectInfo, vulnsForJira, true)
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "", "", projectInfo, vulnsForJira, true)
 
 	var mirroredResponse mirroredResponse
 	if err := json.Unmarshal([]byte(jiraResponse), &mirroredResponse); err != nil {
@@ -49,7 +49,7 @@ func TestOpenJiraTicketWithoutPriorityMappingFunc(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "", "", projectInfo, vulnsForJira, false)
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "", "", projectInfo, vulnsForJira, false)
 
 	var mirroredResponse mirroredResponse
 	if err := json.Unmarshal([]byte(jiraResponse), &mirroredResponse); err != nil {
@@ -75,7 +75,7 @@ func TestOpenJiraTicketWithCustomPriorityMappingFunc(t *testing.T) {
 		panic(err)
 	}
 	os.Setenv("SNYK_JIRA_PRIORITY_FOR_MEDIUM_VULN", "not too bad")
-	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "", "", projectInfo, vulnsForJira, true)
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "", "", projectInfo, vulnsForJira, true)
 
 	var mirroredResponse mirroredResponse
 	if err := json.Unmarshal([]byte(jiraResponse), &mirroredResponse); err != nil {

--- a/jira_test.go
+++ b/jira_test.go
@@ -25,7 +25,28 @@ func TestOpenJiraTicketFunc(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "", "", projectInfo, vulnsForJira, false)
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "", "", projectInfo, vulnsForJira, false)
+
+	assert.Equal("", NotCreatedIssueId)
+	assert.Equal(string(readFixture("./fixtures/results/jiraTicketsOpeningResults")), jiraResponse)
+	fmt.Println("NumberIssueCreated :", NumberIssueCreated)
+
+	return
+}
+
+func TestOpenJiraTicketWithProjectKeyFunc(t *testing.T) {
+	assert := assert.New(t)
+	server := HTTPResponseCheckOpenJiraTickets("/v1/org/123/project/12345678-1234-1234-1234-123456789012/issue/SNYK-JS-MINIMIST-559764/jira-issue")
+
+	defer server.Close()
+
+	projectInfo, _ := jsn.NewJson(readFixture("./fixtures/project.json"))
+	vulnsForJira := make(map[string]interface{})
+	err := json.Unmarshal(readFixture("./fixtures/vulnsForJira.json"), &vulnsForJira)
+	if err != nil {
+		panic(err)
+	}
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "", "Key", "Bug", "", "", "", projectInfo, vulnsForJira, false)
 
 	assert.Equal("", NotCreatedIssueId)
 	assert.Equal(string(readFixture("./fixtures/results/jiraTicketsOpeningResults")), jiraResponse)
@@ -46,7 +67,7 @@ func TestOpenJiraTicketErrorAndRetryFunc(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "", "", projectInfo, vulnsForJira, true)
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "", "", projectInfo, vulnsForJira, true)
 
 	assert.Equal("", NotCreatedIssueId)
 	assert.Equal(string(readFixture("./fixtures/results/jiraTicketsOpeningResults")), jiraResponse)
@@ -68,7 +89,7 @@ func TestOpenJiraMultipleTicketsErrorAndRetryFunc(t *testing.T) {
 		panic(err)
 	}
 
-	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "", "", projectInfo, vulnsForJira, true)
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "", "", projectInfo, vulnsForJira, true)
 
 	assert.Equal("", NotCreatedIssueId)
 	fmt.Println(NumberIssueCreated)
@@ -106,7 +127,7 @@ func TestOpenJiraMultipleTicketsErrorAndRetryAndFailFunc(t *testing.T) {
 		panic(err)
 	}
 
-	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "", "", projectInfo, vulnsForJira, true)
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "", "", projectInfo, vulnsForJira, true)
 
 	assert.Equal(string(readFixture("./fixtures/results/NotCreatedIssueIdSingle")), NotCreatedIssueId)
 	fmt.Println(NumberIssueCreated)
@@ -145,7 +166,7 @@ func TestOpenJiraMultipleTicketsFailureFunc(t *testing.T) {
 		panic(err)
 	}
 
-	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "", "", projectInfo, vulnsForJira, true)
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "", "", projectInfo, vulnsForJira, true)
 
 	fmt.Println(NumberIssueCreated)
 
@@ -183,7 +204,7 @@ func TestOpenJiraTicketWithAssigneeNameFunc(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	numberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "admin", "", "", projectInfo, vulnsForJira, false)
+	numberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "admin", "", "", projectInfo, vulnsForJira, false)
 
 	var mirroredResponse mirroredResponse
 	if err := json.Unmarshal([]byte(jiraResponse), &mirroredResponse); err != nil {
@@ -208,7 +229,7 @@ func TestOpenJiraTicketWithAssigneeIDFunc(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	numberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "Bug", "", "12345", "", projectInfo, vulnsForJira, false)
+	numberIssueCreated, jiraResponse, NotCreatedIssueId := openJiraTickets(server.URL, "123", "123", "123", "", "Bug", "", "12345", "", projectInfo, vulnsForJira, false)
 
 	var mirroredResponse mirroredResponse
 	if err := json.Unmarshal([]byte(jiraResponse), &mirroredResponse); err != nil {

--- a/main.go
+++ b/main.go
@@ -33,7 +33,8 @@ Open Source, so feel free to contribute !
 	projectIDPtr := flag.String("projectID", "", "Optional. Your Project ID. Will sync all projects of your organization if not provided")
 	endpointAPIPtr := flag.String("api", "https://snyk.io/api", "Optional. Your API endpoint for onprem deployments (https://yourdeploymenthostname/api)")
 	apiTokenPtr := flag.String("token", "", "Your API token")
-	jiraProjectIDPtr := flag.String("jiraProjectID", "", "Your JIRA projectID")
+	jiraProjectIDPtr := flag.String("jiraProjectID", "", "Your JIRA projectID (jiraProjectID or jiraProjectKey is required)")
+	jiraProjectKeyPtr := flag.String("jiraProjectKey", "", "Your JIRA projectKey (jiraProjectID or jiraProjectKey is required)")
 	jiraTicketTypePtr := flag.String("jiraTicketType", "Bug", "Optional. Chosen JIRA ticket type")
 	severityPtr := flag.String("severity", "low", "Optional. Your severity threshold")
 	maturityFilterPtr := flag.String("maturityFilter", "", "Optional. include only maturity level(s) separated by commas [mature,proof-of-concept,no-known-exploit,no-data]")
@@ -50,6 +51,7 @@ Open Source, so feel free to contribute !
 	var endpointAPI string = *endpointAPIPtr
 	var apiToken string = *apiTokenPtr
 	var jiraProjectID string = *jiraProjectIDPtr
+	var jiraProjectKey string = *jiraProjectKeyPtr
 	var jiraTicketType string = *jiraTicketTypePtr
 	var severity string = *severityPtr
 	var issueType string = *typePtr
@@ -60,7 +62,7 @@ Open Source, so feel free to contribute !
 	var priorityIsSeverity bool = *priorityIsSeverityPtr
 	var priorityScoreThreshold int = *priorityScorePtr
 
-	if len(orgID) == 0 || len(apiToken) == 0 || len(jiraProjectID) == 0 {
+	if len(orgID) == 0 || len(apiToken) == 0 || (len(jiraProjectID) == 0 && len(jiraProjectKey) == 0) {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
@@ -69,6 +71,10 @@ Open Source, so feel free to contribute !
 
 	if er != nil {
 		log.Fatal(er)
+	}
+
+	if jiraProjectID != "" && jiraProjectKey != "" {
+		log.Fatalf(("INPUT ERROR: You passed both jiraProjectID and jiraProjectKey in parameters\n Please, Use jiraProjectID OR jiraProjectKey, not both"))
 	}
 
 	if priorityScoreThreshold < 0 || priorityScoreThreshold > 1000 {
@@ -99,7 +105,7 @@ Open Source, so feel free to contribute !
 			fmt.Println("4/4 - No new JIRA ticket required")
 		} else {
 			fmt.Println("4/4 - Opening JIRA Tickets")
-			numberIssueCreated, jiraResponse, notCreatedJiraIssues = openJiraTickets(endpointAPI, orgID, apiToken, jiraProjectID, jiraTicketType, assigneeName, assigneeID, labels, projectInfo, vulnsPerPath, priorityIsSeverity)
+			numberIssueCreated, jiraResponse, notCreatedJiraIssues = openJiraTickets(endpointAPI, orgID, apiToken, jiraProjectID, jiraProjectKey, jiraTicketType, assigneeName, assigneeID, labels, projectInfo, vulnsPerPath, priorityIsSeverity)
 
 			if jiraResponse == "" {
 				fmt.Println("Failure to create a ticket(s)")


### PR DESCRIPTION
allow use of either `--jiraProjectID` or `--jiraProjectKey` but not both.


manual tests
- open jira tickets using `--jiraProjectKey`
![image](https://user-images.githubusercontent.com/59706011/137843572-81f93e87-1150-49d6-80e0-92865cfaadc2.png)

- fail when trying to use both `--jiraProjectID` and `--jiraProjectKey`
![image](https://user-images.githubusercontent.com/59706011/137843917-60b68aff-482c-4566-9bca-dfbf3ccbe5b7.png)

- fail when both `--jiraProjectKey` and `--jiraProjectID` are missing
![image](https://user-images.githubusercontent.com/59706011/138016206-cc794857-1e3a-4b33-bb36-6544f97631b1.png)

- regression test - still allow creation with just `--jiraProjectID`
![image](https://user-images.githubusercontent.com/59706011/138015617-a293fe24-836d-4a07-ac01-db88467254ff.png)
