### PR TITLE
Minor/add repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Use the binaries from [the release page](https://github.com/snyk-tech-services/j
     -priorityIsSeverity                                                 // Optional. Set the ticket priority to be based on severity (defaults: Low|Medium|High|Critical=>Low|Medium|High|Highest)
     -labels=<IssueLabel1>,IssueLabel2                                   // Optional. Set JIRA ticket labels
     -priorityScoreThreshold=[0-1000]                                    // Optional. Your min priority score threshold
+    -repoName=<repoName>                                                // Optional. Name of the repository to run jira-ticket-for-new-vuln against. 
 ```
 
 ### Priority is Severity

--- a/fixtures/orgWithRepoName.json
+++ b/fixtures/orgWithRepoName.json
@@ -1,0 +1,105 @@
+{
+  "org": {
+    "name": "test",
+    "id": "f20676f4-3066-40aa-bdf6-ac28ba609xx3"
+  },
+  "projects": [
+    {
+      "id": "a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "name": "test/goof:package.json",
+      "created": "2021-08-31T02:48:41.669Z",
+      "origin": "gitlab",
+      "type": "npm",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 413,
+      "issueCountsBySeverity": {
+        "low": 6,
+        "high": 21,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.0.3",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-25T02:27:39.477Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "master"
+    },
+    {
+      "id": "e4ccfabd-f57e-4df2-a6c6-5b515b93dxx3",
+      "name": "test/snyk-container-scan-docker:latest",
+      "created": "2021-07-16T01:42:13.470Z",
+      "origin": "docker-hub",
+      "type": "apk",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 59,
+      "issueCountsBySeverity": {
+        "low": 2,
+        "high": 17,
+        "medium": 4,
+        "critical": 12
+      },
+      "imageId": "sha256:ed5b47c1d091bfc1c5bb52e0e36c7e3aa2129cf0cbbbf67a76144143c358xxx3",
+      "imageTag": "latest",
+      "imagePlatform": "linux/amd64",
+      "imageBaseImage": "python:3.6.4-alpine3.7",
+      "lastTestedDate": "2021-10-25T00:24:53.091Z",
+      "browseUrl": "https://app.snyk.io/org/antoine-playground/project/e4ccfabd-f57e-4df2-a6c6-5b515b93dxx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": null
+    },
+    {
+      "id": "73b3af82-c8a3-41d0-b301-082182e05xx3",
+      "name": "test/avast-no-project:package.json",
+      "created": "2021-09-27T09:22:29.043Z",
+      "origin": "github-enterprise",
+      "type": "yarn",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 1587,
+      "issueCountsBySeverity": {
+        "low": 1,
+        "high": 25,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.1.0",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-24T21:20:43.572Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/73b3af82-c8a3-41d0-b301-082182e05xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "master"
+    }
+  ]
+}

--- a/fixtures/orgWithRepoNameWithBranch.json
+++ b/fixtures/orgWithRepoNameWithBranch.json
@@ -1,0 +1,105 @@
+{
+  "org": {
+    "name": "test",
+    "id": "f20676f4-3066-40aa-bdf6-ac28ba609xx3"
+  },
+  "projects": [
+    {
+      "id": "a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "name": "test/goof(master):package.json",
+      "created": "2021-08-31T02:48:41.669Z",
+      "origin": "gitlab",
+      "type": "npm",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 413,
+      "issueCountsBySeverity": {
+        "low": 6,
+        "high": 21,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.0.3",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-25T02:27:39.477Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "master"
+    },
+    {
+      "id": "e4ccfabd-f57e-4df2-a6c6-5b515b93dxx3",
+      "name": "test/snyk-container-scan-docker:latest",
+      "created": "2021-07-16T01:42:13.470Z",
+      "origin": "docker-hub",
+      "type": "apk",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 59,
+      "issueCountsBySeverity": {
+        "low": 2,
+        "high": 17,
+        "medium": 4,
+        "critical": 12
+      },
+      "imageId": "sha256:ed5b47c1d091bfc1c5bb52e0e36c7e3aa2129cf0cbbbf67a76144143c358xxx3",
+      "imageTag": "latest",
+      "imagePlatform": "linux/amd64",
+      "imageBaseImage": "python:3.6.4-alpine3.7",
+      "lastTestedDate": "2021-10-25T00:24:53.091Z",
+      "browseUrl": "https://app.snyk.io/org/antoine-playground/project/e4ccfabd-f57e-4df2-a6c6-5b515b93dxx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": null
+    },
+    {
+      "id": "73b3af82-c8a3-41d0-b301-082182e05xx3",
+      "name": "test/avast-no-project:package.json",
+      "created": "2021-09-27T09:22:29.043Z",
+      "origin": "github-enterprise",
+      "type": "yarn",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 1587,
+      "issueCountsBySeverity": {
+        "low": 1,
+        "high": 25,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.1.0",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-24T21:20:43.572Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/73b3af82-c8a3-41d0-b301-082182e05xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "master"
+    }
+  ]
+}

--- a/fixtures/orgWithRepoNameWithBranchTwoProjects.json
+++ b/fixtures/orgWithRepoNameWithBranchTwoProjects.json
@@ -1,0 +1,137 @@
+{
+  "org": {
+    "name": "test",
+    "id": "f20676f4-3066-40aa-bdf6-ac28ba609xx3"
+  },
+  "projects": [
+    {
+      "id": "a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "name": "test/goof(master):package.json",
+      "created": "2021-08-31T02:48:41.669Z",
+      "origin": "gitlab",
+      "type": "npm",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 413,
+      "issueCountsBySeverity": {
+        "low": 6,
+        "high": 21,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.0.3",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-25T02:27:39.477Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "master"
+    },
+    {
+      "id": "a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "name": "test/goof(someBranch):package.json",
+      "created": "2021-08-31T02:48:41.669Z",
+      "origin": "gitlab",
+      "type": "npm",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 413,
+      "issueCountsBySeverity": {
+        "low": 6,
+        "high": 21,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.0.3",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-25T02:27:39.477Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "someBranch"
+    },
+    {
+      "id": "e4ccfabd-f57e-4df2-a6c6-5b515b93dxx3",
+      "name": "test/snyk-container-scan-docker:latest",
+      "created": "2021-07-16T01:42:13.470Z",
+      "origin": "docker-hub",
+      "type": "apk",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 59,
+      "issueCountsBySeverity": {
+        "low": 2,
+        "high": 17,
+        "medium": 4,
+        "critical": 12
+      },
+      "imageId": "sha256:ed5b47c1d091bfc1c5bb52e0e36c7e3aa2129cf0cbbbf67a76144143c358xxx3",
+      "imageTag": "latest",
+      "imagePlatform": "linux/amd64",
+      "imageBaseImage": "python:3.6.4-alpine3.7",
+      "lastTestedDate": "2021-10-25T00:24:53.091Z",
+      "browseUrl": "https://app.snyk.io/org/antoine-playground/project/e4ccfabd-f57e-4df2-a6c6-5b515b93dxx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": null
+    },
+    {
+      "id": "73b3af82-c8a3-41d0-b301-082182e05xx3",
+      "name": "test/avast-no-project:package.json",
+      "created": "2021-09-27T09:22:29.043Z",
+      "origin": "github-enterprise",
+      "type": "yarn",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 1587,
+      "issueCountsBySeverity": {
+        "low": 1,
+        "high": 25,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.1.0",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-24T21:20:43.572Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/73b3af82-c8a3-41d0-b301-082182e05xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "master"
+    }
+  ]
+}

--- a/fixtures/results/orgWithRepoNameResultOneProject.json
+++ b/fixtures/results/orgWithRepoNameResultOneProject.json
@@ -1,0 +1,40 @@
+{
+  "org": {
+    "name": "test",
+    "id": "f20676f4-3066-40aa-bdf6-ac28ba609xx3"
+  },
+  "projects": [
+    {
+      "id": "a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "name": "test/goof:package.json",
+      "created": "2021-08-31T02:48:41.669Z",
+      "origin": "gitlab",
+      "type": "npm",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 413,
+      "issueCountsBySeverity": {
+        "low": 6,
+        "high": 21,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.0.3",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-25T02:27:39.477Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "master"
+    }
+  ]
+}

--- a/fixtures/results/orgWithRepoNameResultOneProjectWithBranch.json
+++ b/fixtures/results/orgWithRepoNameResultOneProjectWithBranch.json
@@ -1,0 +1,40 @@
+{
+  "org": {
+    "name": "test",
+    "id": "f20676f4-3066-40aa-bdf6-ac28ba609xx3"
+  },
+  "projects": [
+    {
+      "id": "a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "name": "test/goof(master):package.json",
+      "created": "2021-08-31T02:48:41.669Z",
+      "origin": "gitlab",
+      "type": "npm",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 413,
+      "issueCountsBySeverity": {
+        "low": 6,
+        "high": 21,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.0.3",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-25T02:27:39.477Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "master"
+    }
+  ]
+}

--- a/fixtures/results/orgWithRepoNameResultTwoProjectWithBranch.json
+++ b/fixtures/results/orgWithRepoNameResultTwoProjectWithBranch.json
@@ -1,0 +1,72 @@
+{
+  "org": {
+    "name": "test",
+    "id": "f20676f4-3066-40aa-bdf6-ac28ba609xx3"
+  },
+  "projects": [
+    {
+      "id": "a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "name": "test/goof(master):package.json",
+      "created": "2021-08-31T02:48:41.669Z",
+      "origin": "gitlab",
+      "type": "npm",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 413,
+      "issueCountsBySeverity": {
+        "low": 6,
+        "high": 21,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.0.3",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-25T02:27:39.477Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "master"
+    },
+    {
+      "id": "a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "name": "test/goof(someBranch):package.json",
+      "created": "2021-08-31T02:48:41.669Z",
+      "origin": "gitlab",
+      "type": "npm",
+      "readOnly": false,
+      "testFrequency": "daily",
+      "isMonitored": true,
+      "totalDependencies": 413,
+      "issueCountsBySeverity": {
+        "low": 6,
+        "high": 21,
+        "medium": 27,
+        "critical": 1
+      },
+      "imageTag": "0.0.3",
+      "imagePlatform": "",
+      "imageBaseImage": "",
+      "lastTestedDate": "2021-10-25T02:27:39.477Z",
+      "browseUrl": "https://app.snyk.io/org/test/project/a0e4716d-0f0d-495b-a77b-bd9ba5692xx3",
+      "owner": null,
+      "importingUser": {
+        "id": "822a3565-9b97-4960-ac2b-7313da220xx3",
+        "name": "test",
+        "username": "test",
+        "email": "test@snyk.io"
+      },
+      "tags": [],
+      "attributes": { "criticality": [], "lifecycle": [], "environment": [] },
+      "branch": "someBranch"
+    }
+  ]
+}

--- a/jira.go
+++ b/jira.go
@@ -51,6 +51,7 @@ type IssueType struct {
 }
 
 func getJiraTickets(endpointAPI string, orgID string, projectID string, token string) map[string]string {
+
 	responseData, err := makeSnykAPIRequest("GET", endpointAPI+"/v1/org/"+orgID+"/project/"+projectID+"/jira-issues", token, nil)
 	if err != nil {
 		fmt.Println("Could not get the tickets")

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ Open Source, so feel free to contribute !
 	labelsPtr := flag.String("labels", "", "Optional. Jira ticket labels")
 	priorityIsSeverityPtr := flag.Bool("priorityIsSeverity", false, "Use issue severity as priority")
 	priorityScorePtr := flag.Int("priorityScoreThreshold", 0, "Optional. Your min priority score threshold [INT between 0 and 1000]")
+	repoNamePtr := flag.String("repoName", "", "Optional. The name of the repo you which to open tickets against. Works only for projects created through Snyk git integration")
 	flag.Parse()
 
 	var orgID string = *orgIDPtr
@@ -61,13 +62,15 @@ Open Source, so feel free to contribute !
 	var labels string = *labelsPtr
 	var priorityIsSeverity bool = *priorityIsSeverityPtr
 	var priorityScoreThreshold int = *priorityScorePtr
+	var repoName string = *repoNamePtr
 
 	if len(orgID) == 0 || len(apiToken) == 0 || (len(jiraProjectID) == 0 && len(jiraProjectKey) == 0) {
+		fmt.Println("Error: Missing arguments\r")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	projectIDs, er := getProjectsIds(projectID, endpointAPI, orgID, apiToken)
+	projectIDs, er := getProjectsIds(projectID, endpointAPI, orgID, apiToken, repoName)
 
 	if er != nil {
 		log.Fatal(er)

--- a/snyk.go
+++ b/snyk.go
@@ -1,14 +1,16 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/michael-go/go-jsn/jsn"
 )
 
-func getOrgProjects(endpointAPI string, orgID string, token string) jsn.Json {
+func getOrgProjects(endpointAPI string, orgID string, token string, repoName string) jsn.Json {
 	responseData, err := makeSnykAPIRequest("GET", endpointAPI+"/v1/org/"+orgID+"/projects", token, nil)
 	if err != nil {
 		fmt.Printf("Could not get the Project(s) for endpoint %s\n", endpointAPI)
@@ -20,17 +22,81 @@ func getOrgProjects(endpointAPI string, orgID string, token string) jsn.Json {
 		log.Fatal(err)
 	}
 
-	return project
+	if repoName != "" {
 
+		orgApiResponse := make(map[string]interface{})
+		json.Unmarshal([]byte(responseData), &orgApiResponse)
+
+		// keeping the content of org and project
+		orgInfo := orgApiResponse["org"].(map[string]interface{})
+		projectsInfo := orgApiResponse["projects"].([]interface{})
+
+		newProject := make(map[string]interface{})
+		newProject["org"] = orgInfo
+
+		var newProjectInfo []interface{}
+		for i := 0; i < len(projectsInfo); i++ {
+
+			var branchName string
+			var NameFromApiArray []string
+			var newNameFromApi string
+
+			// TODO this is a debug
+			// fmt.Println("projectsInfo[i]: ", projectsInfo[i])
+			projectInfo := projectsInfo[i].(map[string]interface{})
+			NameFromApi := projectInfo["name"].(string)
+
+			if projectInfo["branch"] != nil {
+				branchName = "(" + projectInfo["branch"].(string) + ")"
+			}
+
+			newNameFromApi = NameFromApi
+
+			// removing the file name if exist
+			if strings.Contains(NameFromApi, ":") {
+				NameFromApiArray = strings.Split(NameFromApi, ":")
+				// TODO add this to debug option
+				//fmt.Println("Info: repo name found in api response: ", NameFromApiArray[0])
+				newNameFromApi = NameFromApiArray[0]
+			}
+
+			// removing the branch name if exist
+			if strings.Contains(newNameFromApi, branchName) {
+				// TODO add this to debug option
+				//fmt.Println("Info: Removing the branch name from the repoName found in API response", newNameFromApi)
+				newNameFromApi = strings.TrimSuffix(newNameFromApi, branchName)
+			}
+
+			if newNameFromApi == repoName {
+				// TODO add this to debug option
+				//fmt.Println("Found details for project in repo ", repoName)
+				newProjectInfo = append(newProjectInfo, projectInfo)
+			}
+		}
+
+		if newProjectInfo == nil {
+			fmt.Printf("Couldn't find project(s) for corresponding to RepoName %s for endpoint %s", repoName, endpointAPI)
+			log.Fatal()
+		}
+		newProject["projects"] = newProjectInfo
+
+		marshalledNewProject, _ := json.Marshal(newProject)
+		project, err = jsn.NewJson(marshalledNewProject)
+	}
+
+	// TODO add this to debug option
+	// fmt.Println("project: ", project)
+
+	return project
 }
 
-func getProjectsIds(projectID string, endpointAPI string, orgID string, apiToken string) ([]string, error) {
+func getProjectsIds(projectID string, endpointAPI string, orgID string, apiToken string, repoName string) ([]string, error) {
 
 	var projectId []string
 	if len(projectID) == 0 {
 		fmt.Println("Project ID not specified - importing all projects")
 
-		projects := getOrgProjects(endpointAPI, orgID, apiToken)
+		projects := getOrgProjects(endpointAPI, orgID, apiToken, repoName)
 
 		projectIdFound := make([]string, len(projects.K("projects").Array().Elements()))
 		for i := 0; i < len(projects.K("projects").Array().Elements()); i++ {

--- a/snyk_test.go
+++ b/snyk_test.go
@@ -26,7 +26,6 @@ func TestGetProjectDetailsFunc(t *testing.T) {
 	return
 }
 
-
 // Test GetProjectDetails function
 func TestGetOrgProjects(t *testing.T) {
 	expectedTestURL := "/v1/org/123/projects"
@@ -35,11 +34,62 @@ func TestGetOrgProjects(t *testing.T) {
 
 	defer server.Close()
 
-	response := getOrgProjects(server.URL, "123", "123")
+	response := getOrgProjects(server.URL, "123", "123", "")
 
 	opts := jsondiff.DefaultConsoleOptions()
 	marshalledResp, _ := json.Marshal(response)
 	comparison, _ := jsondiff.Compare(readFixture("./fixtures/org.json"), marshalledResp, &opts)
+	assert.Equal("FullMatch", comparison.String())
+
+	return
+}
+
+func TestGetOrgProjectsForRepoName(t *testing.T) {
+	expectedTestURL := "/v1/org/123/projects"
+	assert := assert.New(t)
+	server := HTTPResponseCheckAndStub(expectedTestURL, "orgWithRepoName")
+
+	defer server.Close()
+
+	response := getOrgProjects(server.URL, "123", "123", "test/goof")
+
+	opts := jsondiff.DefaultConsoleOptions()
+	marshalledResp, _ := json.Marshal(response)
+	comparison, _ := jsondiff.Compare(readFixture("./fixtures/results/orgWithRepoNameResultOneProject.json"), marshalledResp, &opts)
+	assert.Equal("FullMatch", comparison.String())
+
+	return
+}
+
+func TestGetOrgProjectsForRepoNameWithBranchName(t *testing.T) {
+	expectedTestURL := "/v1/org/123/projects"
+	assert := assert.New(t)
+	server := HTTPResponseCheckAndStub(expectedTestURL, "orgWithRepoNameWithBranch")
+
+	defer server.Close()
+
+	response := getOrgProjects(server.URL, "123", "123", "test/goof")
+
+	opts := jsondiff.DefaultConsoleOptions()
+	marshalledResp, _ := json.Marshal(response)
+	comparison, _ := jsondiff.Compare(readFixture("./fixtures/results/orgWithRepoNameResultOneProjectWithBranch.json"), marshalledResp, &opts)
+	assert.Equal("FullMatch", comparison.String())
+
+	return
+}
+
+func TestGetOrgProjectsForRepoNameWithBranchNameTwoProjects(t *testing.T) {
+	expectedTestURL := "/v1/org/123/projects"
+	assert := assert.New(t)
+	server := HTTPResponseCheckAndStub(expectedTestURL, "orgWithRepoNameWithBranchTwoProjects")
+
+	defer server.Close()
+
+	response := getOrgProjects(server.URL, "123", "123", "test/goof")
+
+	opts := jsondiff.DefaultConsoleOptions()
+	marshalledResp, _ := json.Marshal(response)
+	comparison, _ := jsondiff.Compare(readFixture("./fixtures/results/orgWithRepoNameResultTwoProjectWithBranch.json"), marshalledResp, &opts)
 	assert.Equal("FullMatch", comparison.String())
 
 	return


### PR DESCRIPTION
Adding a -repoName: create tickets only for project (in the org specified by the -org option) matching this repoName 
Note: Works only for projects created through the git (SCM) integration and match on the name returned in the API
