### PR TITLE
minor: filter issue type to process only vuln and license issue types

### DIFF
--- a/fixtures/projectAggregatedIssuesPerPathnoVulnOrLicenseIssue.json
+++ b/fixtures/projectAggregatedIssuesPerPathnoVulnOrLicenseIssue.json
@@ -1,0 +1,80 @@
+{
+  "issues": [
+    {
+      "issueType": "configuration",
+      "pkgName": "",
+      "pkgVersions": [],
+      "introducedThrough": [],
+      "isPatched": false,
+      "fixInfo": {
+        "isUpgradable": false,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isFixable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      },
+      "id": "523736043",
+      "issueData": {
+        "id": "523736043",
+        "title": "Container is running without root user control",
+        "severity": "medium",
+        "originalSeverity": "medium",
+        "url": "https://snyk.io/security-rules/SNYK-CC-K8S-10",
+        "description": "Container is running without root user control",
+        "disclosureTime": "2021-12-31T08:23:34+00:00",
+        "path": "[DocId: 0].input.spec.template.spec.containers[zecs].securityContext.runAsNonRoot",
+        "violatedPolicyPublicId": "SNYK-CC-K8S-10",
+        "CVSSv3": "",
+        "credit": [],
+        "identifiers": {},
+        "language": "",
+        "nearestFixedInVersion": "",
+        "patches": [],
+        "semver": { "vulnerable": "" },
+        "cvssScore": null,
+        "exploitMaturity": null,
+        "publicationTime": null
+      },
+      "isIgnored": false
+    },
+    {
+      "issueType": "configuration",
+      "pkgName": "",
+      "pkgVersions": [],
+      "introducedThrough": [],
+      "isPatched": false,
+      "fixInfo": {
+        "isUpgradable": false,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isFixable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      },
+      "id": "523736042",
+      "issueData": {
+        "id": "523736042",
+        "title": "Container does not drop all default capabilities",
+        "severity": "medium",
+        "originalSeverity": "medium",
+        "url": "https://snyk.io/security-rules/SNYK-CC-K8S-6",
+        "description": "All default capabilities are not explicitly dropped",
+        "disclosureTime": "2021-12-31T08:23:34+00:00",
+        "path": "[DocId: 0].input.spec.template.spec.containers[zecs].securityContext.capabilities.drop",
+        "violatedPolicyPublicId": "SNYK-CC-K8S-6",
+        "CVSSv3": "",
+        "credit": [],
+        "identifiers": {},
+        "language": "",
+        "nearestFixedInVersion": "",
+        "patches": [],
+        "semver": { "vulnerable": "" },
+        "cvssScore": null,
+        "exploitMaturity": null,
+        "publicationTime": null
+      },
+      "isIgnored": false
+    }
+  ]
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -129,6 +129,21 @@ func HTTPResponseCheckAndStub_() *httptest.Server {
 	}))
 }
 
+// HTTPResponseCheckAndStub Check url match and Stubbing HTTP response
+func HTTPResponseCheckAndStubNoVulnOrLicense() *httptest.Server {
+	var resp []byte
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if "/v1/org/123/project/123/aggregated-issues" == r.RequestURI {
+			resp = readFixture("./fixtures/projectAggregatedIssuesPerPathnoVulnOrLicenseIssue.json")
+		} else {
+			resp = []byte("404 - url mismatch")
+		}
+
+		w.Write(resp)
+	}))
+}
+
 // HTTPResponseStub Stubbing HTTP response
 func HTTPResponseCheckOpenJiraTickets(url string) *httptest.Server {
 	var resp []byte

--- a/vulns.go
+++ b/vulns.go
@@ -85,32 +85,34 @@ func getVulnsWithoutTicket(flags flags, projectID string, maturityFilter []strin
 	vulnsWithAllPaths := make(map[string]interface{})
 
 	for _, e := range j.K("issues").Array().Elements() {
-		if len(e.K("id").String().Value) != 0 {
-			if _, found := tickets[e.K("id").String().Value]; !found {
-				var issueId = e.K("id").String().Value
+		if e.K("issueType").String().Value == "vuln" {
+			if len(e.K("id").String().Value) != 0 {
+				if _, found := tickets[e.K("id").String().Value]; !found {
+					var issueId = e.K("id").String().Value
 
-				bytes, err := json.Marshal(e)
-				if err != nil {
-					log.Fatalln(err)
-				}
-				json.Unmarshal(bytes, &vulnsPerPath)
+					bytes, err := json.Marshal(e)
+					if err != nil {
+						log.Fatalln(err)
+					}
+					json.Unmarshal(bytes, &vulnsPerPath)
 
-				ProjectIssuePathData, err := makeSnykAPIRequest("GET", flags.mandatoryFlags.endpointAPI+"/v1/org/"+flags.mandatoryFlags.orgID+"/project/"+projectID+"/issue/"+issueId+"/paths", flags.mandatoryFlags.apiToken, nil, customDebug)
-				if err != nil {
-					log.Printf("*** ERROR *** Could not get aggregated data from %s org %s project %s issue %s", flags.mandatoryFlags.endpointAPI, flags.mandatoryFlags.orgID, projectID, issueId)
-					log.Fatalln(err)
-				}
-				ProjectIssuePathDataJson, er := jsn.NewJson(ProjectIssuePathData)
-				if er != nil {
-					log.Printf("*** ERROR *** Json creation failed\n")
-					log.Fatalln(er)
-				}
-				vulnsPerPath["from"] = ProjectIssuePathDataJson.K("paths")
-				marshalledvulnsPerPath, err := json.Marshal(vulnsPerPath)
-				vulnsWithAllPaths[issueId], err = jsn.NewJson(marshalledvulnsPerPath)
-				if er != nil {
-					log.Printf("*** ERROR *** Json creation failed\n")
-					log.Fatalln(er)
+					ProjectIssuePathData, err := makeSnykAPIRequest("GET", flags.mandatoryFlags.endpointAPI+"/v1/org/"+flags.mandatoryFlags.orgID+"/project/"+projectID+"/issue/"+issueId+"/paths", flags.mandatoryFlags.apiToken, nil, customDebug)
+					if err != nil {
+						log.Printf("*** ERROR *** Could not get aggregated data from %s org %s project %s issue %s", flags.mandatoryFlags.endpointAPI, flags.mandatoryFlags.orgID, projectID, issueId)
+						log.Fatalln(err)
+					}
+					ProjectIssuePathDataJson, er := jsn.NewJson(ProjectIssuePathData)
+					if er != nil {
+						log.Printf("*** ERROR *** Json creation failed\n")
+						log.Fatalln(er)
+					}
+					vulnsPerPath["from"] = ProjectIssuePathDataJson.K("paths")
+					marshalledvulnsPerPath, err := json.Marshal(vulnsPerPath)
+					vulnsWithAllPaths[issueId], err = jsn.NewJson(marshalledvulnsPerPath)
+					if er != nil {
+						log.Printf("*** ERROR *** Json creation failed\n")
+						log.Fatalln(er)
+					}
 				}
 			}
 		}

--- a/vulns_test.go
+++ b/vulns_test.go
@@ -9,11 +9,6 @@ import (
 // Test getVulnsWithoutTicket function
 func TestGetVulnsWithoutTicketFunc(t *testing.T) {
 
-	//getVulnsWithoutTicket(endpointAPI string, orgID string, projectID string, token string, severity string, issueType string, tickets map[string]string) []interface{} {
-	//return []interface, array of vulns
-	// get http server to return projectIssuesPerPath.json like API would
-	// compare []interface with projectVulnsPerPath.json
-
 	assert := assert.New(t)
 
 	server := HTTPResponseCheckAndStub_()
@@ -60,6 +55,61 @@ func TestGetVulnsWithoutTicketFunc(t *testing.T) {
 	response := getVulnsWithoutTicket(flags, "123", maturityLevels, tickets, cD)
 	//fmt.Println(response)
 	assert.Equal(2, len(response))
+
+	return
+}
+
+// Test that we ignore any issue that is not of type license or a vuln
+// only vuln and license can be in the same aggregated issue reponse atm
+// IAC are separated projects with only configuration type
+// snyk code is in a separated API atm
+
+func TestNoVulnOrLicense(t *testing.T) {
+
+	assert := assert.New(t)
+
+	server := HTTPResponseCheckAndStubNoVulnOrLicense()
+
+	defer server.Close()
+
+	// setting mandatory options
+	Mf := MandatoryFlags{}
+	Mf.orgID = "123"
+	Mf.endpointAPI = server.URL
+	Mf.apiToken = "123"
+	Mf.jiraProjectID = "123"
+	Mf.jiraProjectKey = ""
+
+	// setting optional options
+	Of := optionalFlags{}
+	Of.severity = "low"
+	Of.priorityScoreThreshold = 0
+	Of.issueType = "all"
+	Of.debug = false
+	Of.jiraTicketType = "Bug"
+	Of.assigneeID = ""
+	Of.assigneeName = ""
+	Of.labels = ""
+	Of.priorityIsSeverity = false
+	Of.projectID = ""
+	Of.maturityFilterString = ""
+	Of.ifUpgradeAvailableOnly = false
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
+	// setting debug
+	cD := debug{}
+	cD.setDebug(false)
+
+	var tickets map[string]string
+	tickets = make(map[string]string)
+	var maturityLevels []string
+
+	response := getVulnsWithoutTicket(flags, "123", maturityLevels, tickets, cD)
+	//fmt.Println(response)
+	assert.Equal(0, len(response))
 
 	return
 }


### PR DESCRIPTION
Filtering the aggregated issue reponse on the issue type to process only the vuln and license.
Notes:
 - only vuln and license can be in the SAME aggregated issue reponse atm
 - IAC are separated projects with only 'configuration' type
 - snyk code is in a separated API atm issue type 'code'