### PR TITLE
Feat/Support filtering projects by their attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Use the binaries from [the release page](https://github.com/snyk-tech-services/j
     --dryRun=<true|false>                                                // Optional. result can be found in a json file were the tool is run
     --debug=<true|false>                                                 // Optional. enable debug mode
     --ifUpgradeAvailableOnly=<true|false>                                // Optional. create ticket only for upgradable issues
+    --projectCriticality=[critical,high,medium,low]                      // Optional. Include only projects whose criticality attribute contains one or more of the specified values
+    --projectEnvironment=[backend,frontend,internal,external,mobile,...] // Optional. Include only projects whose environment attribute contains one or more of the specified values
+    --projectLifecycle=[development,sandbox,production]                  // Optional. Include only projects whose lifecycle attribute contains one or more of the specified values
     --configFile                                                         // Path the jira.yaml if not root 
 ```
 

--- a/fixtures/org.json
+++ b/fixtures/org.json
@@ -18,6 +18,11 @@
                 "high": 13,
                 "medium": 15
             },
+            "attributes":{
+                "criticality": ["critical"],
+                "lifecycle": ["production"],
+                "environment": ["frontend", "external"]
+            },
             "remoteRepoUrl": "https://github.com/snyk/goof.git",
             "lastTestedDate": "2019-02-05T06:21:00.000Z",
             "importingUser": {
@@ -48,6 +53,11 @@
                 "high": 13,
                 "medium": 21
             },
+            "attributes":{
+                "criticality": [],
+                "lifecycle": [],
+                "environment": []
+            },
              "remoteRepoUrl": "https://github.com/clojure/clojure.git",
             "lastTestedDate": "2019-02-05T07:01:00.000Z",
             "owner": {
@@ -77,6 +87,11 @@
                 "low": 0,
                 "high": 0,
                 "medium": 0
+            },
+            "attributes":{
+                "criticality": [],
+                "lifecycle": [],
+                "environment": []
             },
             "imageId": "sha256:caf27325b298a6730837023a8a342699c8b7b388b8d878966b064a1320043019",
             "imageTag": "latest",

--- a/snyk.go
+++ b/snyk.go
@@ -1,16 +1,66 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"log"
+	"strings"
 
 	"github.com/michael-go/go-jsn/jsn"
 )
 
-func getOrgProjects(Mf MandatoryFlags, customDebug debug) jsn.Json {
-	responseData, err := makeSnykAPIRequest("GET", Mf.endpointAPI+"/v1/org/"+Mf.orgID+"/projects", Mf.apiToken, nil, customDebug)
+// ProjectsFilter is the top level filter type of filtering Snyk project
+type ProjectsFilter struct {
+	Filters ProjectsFilterBody `json:"filters"`
+}
+
+type ProjectsFilterBody struct {
+	Attributes ProjectsFiltersAttributes `json:"attributes"`
+}
+
+type ProjectsFiltersAttributes struct {
+	Criticality []string `json:"criticality,omitempty"`
+	Environment []string `json:"environment,omitempty"`
+	Lifecycle   []string `json:"lifecycle,omitempty"`
+}
+
+func getOrgProjects(flags flags, customDebug debug) jsn.Json {
+	// According to https://snyk.docs.apiary.io/#reference/projects/all-projects/list-all-projects this should be
+	// a POST API call but historically we used GET here. The following code maintains backwards compatibility for
+	// existing cases where people aren't filtering projects by attributes, as it appears the API does not return
+	// the full project list with empty attribute filters in the request body.
+	verb := "GET"
+	body := ProjectsFilter{}
+
+	if len(flags.optionalFlags.projectCriticality) > 0 {
+		body.Filters.Attributes.Criticality = strings.Split(flags.optionalFlags.projectCriticality, ",")
+		verb = "POST"
+	}
+
+	if len(flags.optionalFlags.projectEnvironment) > 0 {
+		body.Filters.Attributes.Environment = strings.Split(flags.optionalFlags.projectEnvironment, ",")
+		verb = "POST"
+	}
+
+	if len(flags.optionalFlags.projectLifecycle) > 0 {
+		body.Filters.Attributes.Lifecycle = strings.Split(flags.optionalFlags.projectLifecycle, ",")
+		verb = "POST"
+	}
+
+	var marshalledBody []byte
+	var err error
+
+	if verb == "POST" {
+		marshalledBody, err = json.Marshal(body)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		log.Printf("Body: %s\n", string(marshalledBody))
+	}
+
+	responseData, err := makeSnykAPIRequest(verb, flags.mandatoryFlags.endpointAPI+"/v1/org/"+flags.mandatoryFlags.orgID+"/projects", flags.mandatoryFlags.apiToken, marshalledBody, customDebug)
 	if err != nil {
-		log.Printf("*** ERROR *** Could not get the Project(s) for endpoint %s\n", Mf.endpointAPI)
+		log.Printf("*** ERROR *** Could not get the Project(s) for endpoint %s\n", flags.mandatoryFlags.endpointAPI)
 		log.Fatal(err)
 	}
 
@@ -26,9 +76,9 @@ func getProjectsIds(options flags, customDebug debug) ([]string, error) {
 
 	var projectId []string
 	if len(options.optionalFlags.projectID) == 0 {
-		log.Println("*** INFO *** Project ID not specified - importing all projects")
+		log.Println("*** INFO *** Project ID not specified - importing all projects, subject to project attribute filters")
 
-		projects := getOrgProjects(options.mandatoryFlags, customDebug)
+		projects := getOrgProjects(options, customDebug)
 
 		for i := 0; i < len(projects.K("projects").Array().Elements()); i++ {
 			p := projects.K("projects").Array().Elements()[i]

--- a/snyk_test.go
+++ b/snyk_test.go
@@ -54,11 +54,129 @@ func TestGetOrgProjects(t *testing.T) {
 	Mf.apiToken = "123"
 	Mf.jiraProjectID = "123"
 
+	// setting optional options
+	Of := optionalFlags{}
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
 	// setting debug
 	cD := debug{}
 	cD.setDebug(false)
 
-	response := getOrgProjects(Mf, cD)
+	response := getOrgProjects(flags, cD)
+
+	opts := jsondiff.DefaultConsoleOptions()
+	marshalledResp, _ := json.Marshal(response)
+	comparison, _ := jsondiff.Compare(readFixture("./fixtures/org.json"), marshalledResp, &opts)
+	assert.Equal("FullMatch", comparison.String())
+
+	return
+}
+
+// Test GetProjectDetails function with a criticality filter
+func TestGetOrgProjectsCriticality(t *testing.T) {
+	expectedTestURL := "/v1/org/123/projects"
+	assert := assert.New(t)
+	server := HTTPResponseCheckAndStub(expectedTestURL, "org")
+
+	defer server.Close()
+
+	// setting mandatory options
+	Mf := MandatoryFlags{}
+	Mf.orgID = "123"
+	Mf.endpointAPI = server.URL
+	Mf.apiToken = "123"
+	Mf.jiraProjectID = "123"
+
+	// setting optional options
+	Of := optionalFlags{}
+	Of.projectCriticality = "critical"
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
+	// setting debug
+	cD := debug{}
+	cD.setDebug(false)
+
+	response := getOrgProjects(flags, cD)
+
+	opts := jsondiff.DefaultConsoleOptions()
+	marshalledResp, _ := json.Marshal(response)
+	comparison, _ := jsondiff.Compare(readFixture("./fixtures/org.json"), marshalledResp, &opts)
+	assert.Equal("FullMatch", comparison.String())
+
+	return
+}
+
+// Test GetProjectDetails function with an environment filter
+func TestGetOrgProjectsEnvironment(t *testing.T) {
+	expectedTestURL := "/v1/org/123/projects"
+	assert := assert.New(t)
+	server := HTTPResponseCheckAndStub(expectedTestURL, "org")
+
+	defer server.Close()
+
+	// setting mandatory options
+	Mf := MandatoryFlags{}
+	Mf.orgID = "123"
+	Mf.endpointAPI = server.URL
+	Mf.apiToken = "123"
+	Mf.jiraProjectID = "123"
+
+	// setting optional options
+	Of := optionalFlags{}
+	Of.projectEnvironment = "frontend,external"
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
+	// setting debug
+	cD := debug{}
+	cD.setDebug(false)
+
+	response := getOrgProjects(flags, cD)
+
+	opts := jsondiff.DefaultConsoleOptions()
+	marshalledResp, _ := json.Marshal(response)
+	comparison, _ := jsondiff.Compare(readFixture("./fixtures/org.json"), marshalledResp, &opts)
+	assert.Equal("FullMatch", comparison.String())
+
+	return
+}
+
+// Test GetProjectDetails function with a lifecycle filter
+func TestGetOrgProjectsLifecycle(t *testing.T) {
+	expectedTestURL := "/v1/org/123/projects"
+	assert := assert.New(t)
+	server := HTTPResponseCheckAndStub(expectedTestURL, "org")
+
+	defer server.Close()
+
+	// setting mandatory options
+	Mf := MandatoryFlags{}
+	Mf.orgID = "123"
+	Mf.endpointAPI = server.URL
+	Mf.apiToken = "123"
+	Mf.jiraProjectID = "123"
+
+	// setting optional options
+	Of := optionalFlags{}
+	Of.projectLifecycle = "production"
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
+	// setting debug
+	cD := debug{}
+	cD.setDebug(false)
+
+	response := getOrgProjects(flags, cD)
 
 	opts := jsondiff.DefaultConsoleOptions()
 	marshalledResp, _ := json.Marshal(response)

--- a/utils.go
+++ b/utils.go
@@ -78,6 +78,9 @@ set the optional flags structure
 func (Of *optionalFlags) setoptionalFlags(debugPtr bool, dryRunPtr bool, v viper.Viper) {
 
 	Of.projectID = v.GetString("snyk.projectID")
+	Of.projectCriticality = v.GetString("snyk.projectCriticality")
+	Of.projectEnvironment = v.GetString("snyk.projectEnvironment")
+	Of.projectLifecycle = v.GetString("snyk.projectLifecycle")
 	Of.jiraTicketType = v.GetString("jira.jiraTicketType")
 	Of.severity = v.GetString("snyk.severity")
 	Of.issueType = v.GetString("snyk.type")
@@ -90,7 +93,6 @@ func (Of *optionalFlags) setoptionalFlags(debugPtr bool, dryRunPtr bool, v viper
 	Of.debug = debugPtr
 	Of.dryRun = dryRunPtr
 	Of.ifUpgradeAvailableOnly = v.GetBool("snyk.ifUpgradeAvailableOnly")
-
 }
 
 /***
@@ -130,6 +132,9 @@ func (opt *flags) setOption(args []string) {
 	fs.String("jiraProjectID", "", "Your JIRA projectID (jiraProjectID or jiraProjectKey is required)")
 	fs.String("jiraProjectKey", "", "Your JIRA projectKey (jiraProjectID or jiraProjectKey is required)")
 	fs.String("jiraTicketType", "Bug", "Optional. Chosen JIRA ticket type")
+	fs.String("projectCriticality", "", "Optional. Include only projects whose criticality attribute contains one or more of the specified values.")
+	fs.String("projectEnvironment", "", "Optional. Include only projects whose environment attribute contains one or more of the specified values.")
+	fs.String("projectLifecycle", "", "Optional. Include only projects whose lifecycle attribute contains one or more of the specified values.")
 	fs.String("severity", "low", "Optional. Your severity threshold")
 	fs.String("maturityFilter", "", "Optional. include only maturity level(s) separated by commas [mature,proof-of-concept,no-known-exploit,no-data]")
 	fs.String("type", "all", "Optional. Your issue type (all|vuln|license)")
@@ -152,6 +157,9 @@ func (opt *flags) setOption(args []string) {
 	v.BindPFlag("jira.jiraProjectKey", fs.Lookup("jiraProjectKey"))
 
 	v.BindPFlag("snyk.projectID", fs.Lookup("projectID"))
+	v.BindPFlag("snyk.projectCriticality", fs.Lookup("projectCriticality"))
+	v.BindPFlag("snyk.projectEnvironment", fs.Lookup("projectEnvironment"))
+	v.BindPFlag("snyk.projectLifecycle", fs.Lookup("projectLifecycle"))
 	v.BindPFlag("jira.jiraTicketType", fs.Lookup("jiraTicketType"))
 	v.BindPFlag("snyk.severity", fs.Lookup("severity"))
 	v.BindPFlag("snyk.type", fs.Lookup("type"))

--- a/utils_def.go
+++ b/utils_def.go
@@ -24,6 +24,9 @@ type MandatoryFlags struct {
 
 type optionalFlags struct {
 	projectID              string
+	projectCriticality     string
+	projectEnvironment     string
+	projectLifecycle       string
 	jiraTicketType         string
 	severity               string
 	issueType              string


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

I need to roll out Snyk Jira ticket creation gradually across a large number of repositories owned by different teams. There are too many repositories to enable ticket creation for all of them at once: some repositories are a higher priority than others due to the business risk of the repository, e.g. whether they are in production and the criticality of the code to the org.

In order to automatically raise tickets for the correct set of projects in scope, I need to only create Jira tickets for a subset of projects which have certain attributes. I want to be able to filter by the criticality, environment and lifecycle of each project. This allows me to change the attributes of projects one by one in order to bring them gradually into scope for Jira ticket creation. (There are some projects which are only experimental internal things for which I may never want Jira tickets raised so those will probably never have attributes set to be in scope)

### Notes for the reviewer

Example of running this locally:

```
./snyk-jira-sync-<yourplatform>  \
    --orgID=xxxxxx \
    --token=xxxxxx \
    --jiraProjectKey=xx \
    --projectCriticality=critical,high
```

I had wondered whether the `--projectCriticality` should be a single value rather like the existing `--severity` flag, since the criticality seems to have a similar intended use to indicate the minimum level of something. However, I note that the Snyk UI currently allows multiple criticality values on the same project so I've coded this to accept multiple values in case anyone depends on that.

I also noticed that the code was using a GET request to list all projects, however the [API doc here](https://snyk.docs.apiary.io/#reference/projects/all-projects/list-all-projects) specifies that it's a POST API, which makes sense due to the ability to post a body containing filter parameters. It wasn't clear to me if it would break anything to switch to POST so out of caution I coded it to only POST when there's a filter to send, to hopefully minimise the odds I break anything for others 😅

I also noticed that null attribute value arrays were rejected in the filter body, so I marked them `omitempty` which avoids errors when a specific filter is absent.

I hope this feature will be helpful to others. I'm sorry if I haven't done something quite right for the project, it's my first time contributing here so I'm happy to improve things as needed. The above links (https://github.com/snyk/general/wiki/Tests, https://github.com/snyk/general/wiki/Documentation and https://github.com/snyk/general/wiki/Git) aren't accessible to me so I've done my best to match recent past practices as best I can. I'm away until Monday but will catch up then with any feedback. 🙂

### More information

- [Link to documentation](https://github.com/snyk-tech-services/jira-tickets-for-new-vulns/wiki/)

### Screenshots

Let me know if you need any
