### PR TITLE
minor: remove unused import

### DIFF
--- a/snyk_utils.go
+++ b/snyk_utils.go
@@ -3,10 +3,8 @@ package main
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 )


### PR DESCRIPTION
Remove import of fmt and os. Not used anymore.

