### PR TITLE
Minor/support filtering projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Use the binaries from [the release page](https://github.com/snyk-tech-services/j
     --dryRun=<true|false>                                                // Optional. result can be found in a json file were the tool is run
     --debug=<true|false>                                                 // Optional. enable debug mode
     --ifUpgradeAvailableOnly=<true|false>                                // Optional. create ticket only for upgradable issues
+    --projectCriticality=[critical,high,medium,low]                      // Optional. Include only projects whose criticality attribute contains one or more of the specified values
+    --projectEnvironment=[backend,frontend,internal,external,mobile,...] // Optional. Include only projects whose environment attribute contains one or more of the specified values
+    --projectLifecycle=[development,sandbox,production]                  // Optional. Include only projects whose lifecycle attribute contains one or more of the specified values
     --configFile                                                         // Path the jira.yaml if not root 
 ```
 

--- a/fixtures/org.json
+++ b/fixtures/org.json
@@ -18,6 +18,11 @@
                 "high": 13,
                 "medium": 15
             },
+            "attributes":{
+                "criticality": ["critical"],
+                "lifecycle": ["production"],
+                "environment": ["frontend", "external"]
+            },
             "remoteRepoUrl": "https://github.com/snyk/goof.git",
             "lastTestedDate": "2019-02-05T06:21:00.000Z",
             "importingUser": {
@@ -48,6 +53,11 @@
                 "high": 13,
                 "medium": 21
             },
+            "attributes":{
+                "criticality": [],
+                "lifecycle": [],
+                "environment": []
+            },
              "remoteRepoUrl": "https://github.com/clojure/clojure.git",
             "lastTestedDate": "2019-02-05T07:01:00.000Z",
             "owner": {
@@ -77,6 +87,11 @@
                 "low": 0,
                 "high": 0,
                 "medium": 0
+            },
+            "attributes":{
+                "criticality": [],
+                "lifecycle": [],
+                "environment": []
             },
             "imageId": "sha256:caf27325b298a6730837023a8a342699c8b7b388b8d878966b064a1320043019",
             "imageTag": "latest",

--- a/snyk.go
+++ b/snyk.go
@@ -1,18 +1,72 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"log"
+	"strings"
 
 	"github.com/michael-go/go-jsn/jsn"
 )
 
-func getOrgProjects(Mf MandatoryFlags, customDebug debug) (jsn.Json, error) {
-	var projectsAPI =  Mf.endpointAPI+"/v1/org/"+Mf.orgID+"/projects";
-	responseData, err := makeSnykAPIRequest("GET", projectsAPI, Mf.apiToken, nil, customDebug)
+// ProjectsFilter is the top level filter type of filtering Snyk project
+type ProjectsFilter struct {
+	Filters ProjectsFilterBody `json:"filters"`
+}
+
+type ProjectsFilterBody struct {
+	Attributes ProjectsFiltersAttributes `json:"attributes"`
+}
+
+type ProjectsFiltersAttributes struct {
+	Criticality []string `json:"criticality,omitempty"`
+	Environment []string `json:"environment,omitempty"`
+	Lifecycle   []string `json:"lifecycle,omitempty"`
+}
+
+func getOrgProjects(flags flags, customDebug debug) (jsn.Json, error) {
+	// According to https://snyk.docs.apiary.io/#reference/projects/all-projects/list-all-projects this should be
+	// a POST API call but historically we used GET here. The following code maintains backwards compatibility for
+	// existing cases where people aren't filtering projects by attributes, as it appears the API does not return
+	// the full project list with empty attribute filters in the request body.
+	verb := "GET"
+	body := ProjectsFilter{}
+	projectsAPI := flags.mandatoryFlags.endpointAPI + "/v1/org/" + flags.mandatoryFlags.orgID + "/projects"
+
+	if len(flags.optionalFlags.projectCriticality) > 0 {
+		body.Filters.Attributes.Criticality = strings.Split(flags.optionalFlags.projectCriticality, ",")
+		verb = "POST"
+	}
+
+	if len(flags.optionalFlags.projectEnvironment) > 0 {
+		body.Filters.Attributes.Environment = strings.Split(flags.optionalFlags.projectEnvironment, ",")
+		verb = "POST"
+	}
+
+	if len(flags.optionalFlags.projectLifecycle) > 0 {
+		body.Filters.Attributes.Lifecycle = strings.Split(flags.optionalFlags.projectLifecycle, ",")
+		verb = "POST"
+	}
+
+	var marshalledBody []byte
+	var err error
+
+	if verb == "POST" {
+		marshalledBody, err = json.Marshal(body)
+		if err != nil {
+			log.Printf("*** ERROR *** Not able to read attributes %s\n", projectsAPI)
+			errorMessage := "Failure, Not able to read attributes\n"
+			err = errors.New(errorMessage)
+			verb = "GET"
+			marshalledBody = nil
+		}
+	}
+
+	responseData, err := makeSnykAPIRequest(verb, projectsAPI, flags.mandatoryFlags.apiToken, marshalledBody, customDebug)
 	if err != nil {
-		log.Printf("*** ERROR *** Could not get the Project(s) for endpoint %s\n", projectsAPI)
-		errorMessage := "Failure, Could not get the Project(s) for endpoint " + projectsAPI + "\n"
+		filters := "projectCriticality: " + flags.optionalFlags.projectCriticality + "\n projectEnvironment: " + flags.optionalFlags.projectEnvironment + "\n projectLifecycle: " + flags.optionalFlags.projectLifecycle
+		log.Printf("*** ERROR *** Could not list the Project(s) for endpoint %s\n Applied Filters: %s\n", projectsAPI, filters)
+		errorMessage := "Failure, Could not list the Project(s) for endpoint " + projectsAPI + ".\n" + "Applied filters: " + filters
 		err = errors.New(errorMessage)
 	}
 
@@ -30,10 +84,10 @@ func getProjectsIds(options flags, customDebug debug) ([]string, error) {
 
 	var projectId []string
 	if len(options.optionalFlags.projectID) == 0 {
-		log.Println("*** INFO *** Project ID not specified, importing all projects")
+		filters := "projectCriticality: " + options.optionalFlags.projectCriticality + "\n projectEnvironment: " + options.optionalFlags.projectEnvironment + "\n projectLifecycle: " + options.optionalFlags.projectLifecycle
+		log.Println("*** INFO *** Project ID not specified - listing all projects that match the following filers: ", filters)
 
-		projects, err := getOrgProjects(options.mandatoryFlags, customDebug)
-
+		projects, err := getOrgProjects(options, customDebug)
 		if err != nil {
 			return nil, err
 		}

--- a/snyk_test.go
+++ b/snyk_test.go
@@ -54,11 +54,129 @@ func TestGetOrgProjects(t *testing.T) {
 	Mf.apiToken = "123"
 	Mf.jiraProjectID = "123"
 
+	// setting optional options
+	Of := optionalFlags{}
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
 	// setting debug
 	cD := debug{}
 	cD.setDebug(false)
 
-	response, _ := getOrgProjects(Mf, cD)
+	response, _ := getOrgProjects(flags, cD)
+
+	opts := jsondiff.DefaultConsoleOptions()
+	marshalledResp, _ := json.Marshal(response)
+	comparison, _ := jsondiff.Compare(readFixture("./fixtures/org.json"), marshalledResp, &opts)
+	assert.Equal("FullMatch", comparison.String())
+
+	return
+}
+
+// Test GetProjectDetails function with a criticality filter
+func TestGetOrgProjectsCriticality(t *testing.T) {
+	expectedTestURL := "/v1/org/123/projects"
+	assert := assert.New(t)
+	server := HTTPResponseCheckAndStub(expectedTestURL, "org")
+
+	defer server.Close()
+
+	// setting mandatory options
+	Mf := MandatoryFlags{}
+	Mf.orgID = "123"
+	Mf.endpointAPI = server.URL
+	Mf.apiToken = "123"
+	Mf.jiraProjectID = "123"
+
+	// setting optional options
+	Of := optionalFlags{}
+	Of.projectCriticality = "critical"
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
+	// setting debug
+	cD := debug{}
+	cD.setDebug(false)
+
+	response, _ := getOrgProjects(flags, cD)
+
+	opts := jsondiff.DefaultConsoleOptions()
+	marshalledResp, _ := json.Marshal(response)
+	comparison, _ := jsondiff.Compare(readFixture("./fixtures/org.json"), marshalledResp, &opts)
+	assert.Equal("FullMatch", comparison.String())
+
+	return
+}
+
+// Test GetProjectDetails function with an environment filter
+func TestGetOrgProjectsEnvironment(t *testing.T) {
+	expectedTestURL := "/v1/org/123/projects"
+	assert := assert.New(t)
+	server := HTTPResponseCheckAndStub(expectedTestURL, "org")
+
+	defer server.Close()
+
+	// setting mandatory options
+	Mf := MandatoryFlags{}
+	Mf.orgID = "123"
+	Mf.endpointAPI = server.URL
+	Mf.apiToken = "123"
+	Mf.jiraProjectID = "123"
+
+	// setting optional options
+	Of := optionalFlags{}
+	Of.projectEnvironment = "frontend,external"
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
+	// setting debug
+	cD := debug{}
+	cD.setDebug(false)
+
+	response, _ := getOrgProjects(flags, cD)
+
+	opts := jsondiff.DefaultConsoleOptions()
+	marshalledResp, _ := json.Marshal(response)
+	comparison, _ := jsondiff.Compare(readFixture("./fixtures/org.json"), marshalledResp, &opts)
+	assert.Equal("FullMatch", comparison.String())
+
+	return
+}
+
+// Test GetProjectDetails function with a lifecycle filter
+func TestGetOrgProjectsLifecycle(t *testing.T) {
+	expectedTestURL := "/v1/org/123/projects"
+	assert := assert.New(t)
+	server := HTTPResponseCheckAndStub(expectedTestURL, "org")
+
+	defer server.Close()
+
+	// setting mandatory options
+	Mf := MandatoryFlags{}
+	Mf.orgID = "123"
+	Mf.endpointAPI = server.URL
+	Mf.apiToken = "123"
+	Mf.jiraProjectID = "123"
+
+	// setting optional options
+	Of := optionalFlags{}
+	Of.projectLifecycle = "production"
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
+	// setting debug
+	cD := debug{}
+	cD.setDebug(false)
+
+	response, _ := getOrgProjects(flags, cD)
 
 	opts := jsondiff.DefaultConsoleOptions()
 	marshalledResp, _ := json.Marshal(response)

--- a/utils.go
+++ b/utils.go
@@ -78,6 +78,9 @@ set the optional flags structure
 func (Of *optionalFlags) setoptionalFlags(debugPtr bool, dryRunPtr bool, v viper.Viper) {
 
 	Of.projectID = v.GetString("snyk.projectID")
+	Of.projectCriticality = v.GetString("snyk.projectCriticality")
+	Of.projectEnvironment = v.GetString("snyk.projectEnvironment")
+	Of.projectLifecycle = v.GetString("snyk.projectLifecycle")
 	Of.jiraTicketType = v.GetString("jira.jiraTicketType")
 	Of.severity = v.GetString("snyk.severity")
 	Of.issueType = v.GetString("snyk.type")
@@ -90,7 +93,6 @@ func (Of *optionalFlags) setoptionalFlags(debugPtr bool, dryRunPtr bool, v viper
 	Of.debug = debugPtr
 	Of.dryRun = dryRunPtr
 	Of.ifUpgradeAvailableOnly = v.GetBool("snyk.ifUpgradeAvailableOnly")
-
 }
 
 /***
@@ -130,6 +132,9 @@ func (opt *flags) setOption(args []string) {
 	fs.String("jiraProjectID", "", "Your JIRA projectID (jiraProjectID or jiraProjectKey is required)")
 	fs.String("jiraProjectKey", "", "Your JIRA projectKey (jiraProjectID or jiraProjectKey is required)")
 	fs.String("jiraTicketType", "Bug", "Optional. Chosen JIRA ticket type")
+	fs.String("projectCriticality", "", "Optional. Include only projects whose criticality attribute contains one or more of the specified values.")
+	fs.String("projectEnvironment", "", "Optional. Include only projects whose environment attribute contains one or more of the specified values.")
+	fs.String("projectLifecycle", "", "Optional. Include only projects whose lifecycle attribute contains one or more of the specified values.")
 	fs.String("severity", "low", "Optional. Your severity threshold")
 	fs.String("maturityFilter", "", "Optional. include only maturity level(s) separated by commas [mature,proof-of-concept,no-known-exploit,no-data]")
 	fs.String("type", "all", "Optional. Your issue type (all|vuln|license)")
@@ -152,6 +157,9 @@ func (opt *flags) setOption(args []string) {
 	v.BindPFlag("jira.jiraProjectKey", fs.Lookup("jiraProjectKey"))
 
 	v.BindPFlag("snyk.projectID", fs.Lookup("projectID"))
+	v.BindPFlag("snyk.projectCriticality", fs.Lookup("projectCriticality"))
+	v.BindPFlag("snyk.projectEnvironment", fs.Lookup("projectEnvironment"))
+	v.BindPFlag("snyk.projectLifecycle", fs.Lookup("projectLifecycle"))
 	v.BindPFlag("jira.jiraTicketType", fs.Lookup("jiraTicketType"))
 	v.BindPFlag("snyk.severity", fs.Lookup("severity"))
 	v.BindPFlag("snyk.type", fs.Lookup("type"))

--- a/utils_def.go
+++ b/utils_def.go
@@ -24,6 +24,9 @@ type MandatoryFlags struct {
 
 type optionalFlags struct {
 	projectID              string
+	projectCriticality     string
+	projectEnvironment     string
+	projectLifecycle       string
 	jiraTicketType         string
 	severity               string
 	issueType              string


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The tests don't run from fork, so I cherry-picked the commit.
Just made an adjustment in snyk.go instead of failing if we cannot unmarshalled the attribute, we fall back to the a get method with body at nil like it was originally.
