### PR TITLE
minor: improved error messaging, display raw HTTP messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,6 @@ jobs:
       steps:
         - checkout
         - run: go test -v
-        - snyk/scan:
-            fail-on-issues: true
-            monitor-on-build: true
-            token-variable: SNYK_TOKEN
         - run: ./generate-binaries.sh
         - persist_to_workspace:
             root: .
@@ -36,10 +32,6 @@ jobs:
       steps:
         - checkout
         - run: go test -v
-        - snyk/scan:
-            fail-on-issues: true
-            monitor-on-build: false
-            token-variable: SNYK_TOKEN
 
   build-test-from-fork:
       docker:
@@ -65,8 +57,8 @@ jobs:
       - run: sha256sum dist/snyk-jira-sync-win.exe > dist/snyk-jira-sync-win.exe.sha256
       - run:
           name: "Publish Release on GitHub"
-          command: |    
-            VERSIONJUMP=$(git log --oneline -1 --pretty=%B | cat | grep -E 'minor|major|patch' | awk -F ':' '{print $1}')   
+          command: |
+            VERSIONJUMP=$(git log --oneline -1 --pretty=%B | cat | grep -E 'minor|major|patch' | awk -F ':' '{print $1}')
             VERSION=$(/workdir/nextver.sh "$VERSIONJUMP")
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${VERSION} dist/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 dist/
-
-dist/
+.dccache

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,17 @@
-module github.com/snyk-tech-services/ira-tickets-for-new-vulns
+module github.com/snyk-tech-services/jira-tickets-for-new-vulns
 
 go 1.13
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/btree v1.0.0 // indirect
 	github.com/kentaro-m/blackfriday-confluence v0.0.0-20191222131424-8d627b5b68dc
 	github.com/michael-go/go-jsn v0.0.0-20171026145752-f106662b224a
 	github.com/nsf/jsondiff v0.0.0-20190712045011-8443391ee9b6
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/dl v0.0.0-20220609182932-6cd2f0e318f7 // indirect
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/russross/blackfriday.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+golang.org/dl v0.0.0-20220609182932-6cd2f0e318f7 h1:Z5Cqsjkc4mQlGBF0cgj5S3+M1aW30Wv9Mgg5maRRQhw=
+golang.org/dl v0.0.0-20220609182932-6cd2f0e318f7/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/jira.go
+++ b/jira.go
@@ -12,7 +12,7 @@ import (
 	"github.com/michael-go/go-jsn/jsn"
 )
 
-// JiraIssue represents the top level Struct for JIRA issue description
+// JiraIssue represents the top level Struct for Jira issue description
 type JiraIssue struct {
 	Fields Field `json:"fields"`
 }
@@ -22,7 +22,7 @@ type PriorityType struct {
 	Name string `json:"name,omitempty"`
 }
 
-// Field represents a JIRA issue basic fields
+// Field represents a Jira issue basic fields
 type Field struct {
 	Projects    Project       `json:"project"`
 	Summary     string        `json:"summary"`
@@ -33,13 +33,13 @@ type Field struct {
 	Labels      []string      `json:"labels,omitempty"`
 }
 
-// Assignee is the account ID of the JIRA user to assign tickets to
+// Assignee is the account ID of the Jira user to assign tickets to
 type Assignee struct {
 	Name      string `json:"name,omitempty"`
 	AccountId string `json:"accountId,omitempty"`
 }
 
-// Project is the JIRA project ID or Key
+// Project is the Jira project ID or Key
 type Project struct {
 	ID  string `json:"id,omitempty"`
 	Key string `json:"key,omitempty"`
@@ -53,14 +53,14 @@ type IssueType struct {
 func getJiraTickets(Mf MandatoryFlags, projectID string, customDebug debug) (map[string]string, error) {
 	responseData, err := makeSnykAPIRequest("GET", Mf.endpointAPI+"/v1/org/"+Mf.orgID+"/project/"+projectID+"/jira-issues", Mf.apiToken, nil, customDebug)
 	if err != nil {
-		customDebug.Debug("*** ERROR *** Could not get the tickets")
+		customDebug.Debug("*** ERROR *** Could not get the Jira issues via Snyk API")
 		return nil, errors.New("Could not get the tickets")
 	}
 
 	tickets, err := jsn.NewJson(responseData)
 	if err != nil {
-		customDebug.Debug("*** ERROR *** Could not read the tickets")
-		return nil, errors.New("Could not read the tickets")
+		customDebug.Debug("*** ERROR *** Could not read Jira issues via Snyk API")
+		return nil, errors.New("Could not read Jira issues via Snyk API")
 	}
 
 	tickRefs := make(map[string]string)
@@ -80,7 +80,7 @@ return error: if request or ticket creation failure
 create a ticket for a specific vuln
 	ticket is created and send to snyk jira ticket creation API endpoint
 ***/
-func openJiraTicket(flags flags, projectInfo jsn.Json, vulnForJira interface{}, customDebug debug) ([]byte, *Tickets, error) {
+func openJiraTicket(flags flags, projectInfo jsn.Json, vulnForJira interface{}, customDebug debug) ([]byte, *Tickets, error, string) {
 
 	jsonVuln, _ := jsn.NewJson(vulnForJira)
 	issueType := jsonVuln.K("data").K("attributes").K("issueType").String().Value
@@ -104,9 +104,10 @@ func openJiraTicket(flags flags, projectInfo jsn.Json, vulnForJira interface{}, 
 	jiraTicket.Fields.IssueTypes.Name = flags.optionalFlags.jiraTicketType
 
 	projectInfoId := projectInfo.K("id").String().Value
+	var jiraApiUrl = flags.mandatoryFlags.endpointAPI+"/v1/org/"+flags.mandatoryFlags.orgID+"/project/"+projectInfoId+"/issue/"+vulnID+"/jira-issue"
 
 	if projectInfoId == "" {
-		return nil, nil, errors.New("Failure, Could not retrieve project ID")
+		return nil, nil, errors.New("Failure, Could not retrieve project ID"), jiraApiUrl
 	}
 
 	if flags.optionalFlags.labels != "" {
@@ -151,7 +152,7 @@ func openJiraTicket(flags flags, projectInfo jsn.Json, vulnForJira interface{}, 
 	ticket, err := json.Marshal(jiraTicket)
 	if err != nil {
 		customDebug.Debug("*** ERROR *** Error while creating the ticket")
-		return nil, nil, errors.New("Failure, Failure to create ticket(s)")
+		return nil, nil, errors.New("Failure, Failure to create ticket(s)"), jiraApiUrl
 	}
 
 	// Add Mandatory filed to the ticket
@@ -159,7 +160,7 @@ func openJiraTicket(flags flags, projectInfo jsn.Json, vulnForJira interface{}, 
 		ticket = addMandatoryFieldToTicket(ticket, flags.customMandatoryJiraFields, customDebug)
 	}
 
-	customDebug.Debugf("*** INFO *** Ticket to be send %s", string(ticket))
+	customDebug.Debugf("*** INFO *** Ticket data to be sent %s", string(ticket))
 
 	// create ticket struct to add in the logfile
 	// test is dryRun, if not log only what's have been created
@@ -173,19 +174,19 @@ func openJiraTicket(flags flags, projectInfo jsn.Json, vulnForJira interface{}, 
 	// check that vulnId exist and dryRun is off
 	if len(vulnID) != 0 && !flags.optionalFlags.dryRun {
 		var er error
-		responseData, er := makeSnykAPIRequest("POST", flags.mandatoryFlags.endpointAPI+"/v1/org/"+flags.mandatoryFlags.orgID+"/project/"+projectInfoId+"/issue/"+vulnID+"/jira-issue", flags.mandatoryFlags.apiToken, ticket, customDebug)
+		responseData, er := makeSnykAPIRequest("POST", jiraApiUrl, flags.mandatoryFlags.apiToken, ticket, customDebug)
 
 		if er != nil {
 			if er.Error() == "Failed too many time with 50x errors" {
-				return nil, nil, errors.New("Failed too many time with 50x errors")
+				return nil, nil, errors.New("Failed too many time with 50x errors"), jiraApiUrl
 			}
 			customDebug.Debug("*** ERROR *** Request failed")
-			return nil, nil, errors.New("Failure, Failure to create ticket(s)")
+			return nil, nil, errors.New(er.Error()), jiraApiUrl
 		}
 
 		if bytes.Equal(responseData, nil) {
-			customDebug.Debugf("*** ERROR *** Request response from %s is empty\n", flags.mandatoryFlags.endpointAPI)
-			return nil, nil, errors.New("Failure, Failure to create ticket(s)")
+			customDebug.Debugf("*** ERROR *** Request response from %s is empty\n", jiraApiUrl)
+			return nil, nil, errors.New("Received empty response from /jira-issues API"), jiraApiUrl
 		}
 
 		// create ticket struct to add in the json logfile
@@ -196,16 +197,16 @@ func openJiraTicket(flags flags, projectInfo jsn.Json, vulnForJira interface{}, 
 			JiraIssueDetail: getJiraTicketId(responseData),
 		}
 
-		return responseData, ticketFile, nil
+		return responseData, ticketFile, nil, jiraApiUrl
 	}
-	return nil, ticketFile, errors.New("*** ERROR *** Failure to create ticket, vuln ID is empty")
+	return nil, ticketFile, errors.New("*** ERROR *** Failed to create ticket, vuln ID is empty"), jiraApiUrl
 }
 
-func displayErrorForIssue(vulnForJira interface{}, endpointAPI string, customDebug debug) string {
+func displayErrorForIssue(vulnForJira interface{}, endpointAPI string, error error) string {
 
 	jsonVuln, _ := jsn.NewJson(vulnForJira)
 	vulnID := jsonVuln.K("id").String().Value
-	customDebug.Debugf("*** ERROR *** Request to %s failed too many time\n Ticket cannot be created for this issue: %s\n", endpointAPI, vulnID)
+	log.Printf("*** ERROR *** Request to %s failed.\nERROR: %s", endpointAPI, error)
 
 	return vulnID + "\n"
 }
@@ -230,11 +231,10 @@ func openJiraTickets(flags flags, projectInfo jsn.Json, vulnsForJira map[string]
 
 		RequestFailed = false
 
-		customDebug.Debug("*** INFO *** Trying to open ticket for vuln", vulnForJira)
-
-		responseDataAggregatedByte, ticket, err := openJiraTicket(flags, projectInfo, vulnForJira, customDebug)
+		customDebug.Debug("*** INFO *** Trying to open ticket for vuln:", vulnForJira)
+		responseDataAggregatedByte, ticket, err, jiraApiUrl := openJiraTicket(flags, projectInfo, vulnForJira, customDebug)
 		if err != nil {
-			customDebug.Debugf("*** ERROR *** opening jira ticket failed endpoint %s\n", flags.mandatoryFlags.endpointAPI)
+			customDebug.Debugf("*** ERROR *** Opening Jira ticket failed %s\n", jiraApiUrl)
 			RequestFailed = true
 		}
 
@@ -244,12 +244,12 @@ func openJiraTickets(flags flags, projectInfo jsn.Json, vulnsForJira map[string]
 			if RequestFailed == true {
 				for numberOfRetries := 0; numberOfRetries < MaxNumberOfRetry; numberOfRetries++ {
 
-					customDebug.Debug("*** INFO *** Retrying with priorityIsSeverity set to false, max retry ", MaxNumberOfRetry)
+					customDebug.Debug("*** INFO *** Retrying with priorityIsSeverity set to false, max retries=", MaxNumberOfRetry)
 
 					flags.optionalFlags.priorityIsSeverity = false
-					responseDataAggregatedByte, ticket, err = openJiraTicket(flags, projectInfo, vulnForJira, customDebug)
+					responseDataAggregatedByte, ticket, err, jiraApiUrl = openJiraTicket(flags, projectInfo, vulnForJira, customDebug)
 					if err != nil {
-						fullListNotCreatedIssue += displayErrorForIssue(vulnForJira, flags.mandatoryFlags.endpointAPI, customDebug)
+						fullListNotCreatedIssue += displayErrorForIssue(vulnForJira, jiraApiUrl, err)
 					} else {
 						RequestFailed = false
 						break
@@ -257,7 +257,7 @@ func openJiraTickets(flags flags, projectInfo jsn.Json, vulnsForJira map[string]
 				}
 			}
 			if RequestFailed == true && strings.Contains(strings.ToLower(string(responseDataAggregatedByte)), "error") {
-				fullListNotCreatedIssue += displayErrorForIssue(vulnForJira, flags.mandatoryFlags.endpointAPI, customDebug)
+				fullListNotCreatedIssue += displayErrorForIssue(vulnForJira, jiraApiUrl, err)
 				continue
 			}
 
@@ -281,7 +281,7 @@ func openJiraTickets(flags flags, projectInfo jsn.Json, vulnsForJira map[string]
 	project[projectIdString] = ticketArray
 
 	if fullResponseDataAggregated == "" && !flags.optionalFlags.dryRun {
-		log.Printf("*** ERROR *** Request response from %s is empty\n", flags.mandatoryFlags.endpointAPI)
+		customDebug.Debugf("*** ERROR *** Request response from %s is empty\n", flags.mandatoryFlags.endpointAPI)
 	}
 
 	customDebug.Debugf("*** INFO *** %d issueCreated, fullResponseDataAggregated: %s", issueCreated, fullResponseDataAggregated)

--- a/jira_snyk_code_test.go
+++ b/jira_snyk_code_test.go
@@ -87,9 +87,10 @@ func TestOpenJiraTicketCodeOnly(t *testing.T) {
 	cD := debug{}
 	cD.setDebug(false)
 
-	responseDataAggregatedByte, ticket, err := openJiraTicket(flags, projectInfo, codeIssueForJira, cD)
+	responseDataAggregatedByte, ticket, err, jiraApiUrl := openJiraTicket(flags, projectInfo, codeIssueForJira, cD)
 
 	assert.NotNil(t, ticket)
+	assert.NotNil(t, jiraApiUrl)
 	assert.NotNil(t, responseDataAggregatedByte)
 
 }

--- a/jira_utils.go
+++ b/jira_utils.go
@@ -101,7 +101,7 @@ func formatJiraTicket(jsonVuln jsn.Json, projectInfo jsn.Json) *JiraIssue {
 	descriptionFromIssue := ""
 
 	if issueData.K("type").String().Value == "license" {
-		descriptionFromIssue = `This dependency is infriguing your organization license policy. 
+		descriptionFromIssue = `This dependency is infriguing your organization license policy.
 								Refer to the Reporting tab for possible instructions from your legal team.`
 	}
 

--- a/main.go
+++ b/main.go
@@ -8,26 +8,6 @@ import (
 )
 
 func main() {
-
-	asciiArt :=
-		`
-================================================
-  _____             _      _______        _     
- / ____|           | |    |__   __|      | |    
-| (___  _ __  _   _| | __    | | ___  ___| |__  
- \___ \| '_ \| | | | |/ /    | |/ _ \/ __| '_ \ 
- ____) | | | | |_| |   <     | |  __/ (__| | | |
-|_____/|_| |_|\__, |_|\_\    |_|\___|\___|_| |_|
-              __/ /                            
-             |___/                             
-================================================
-JIRA Syncing Tool
-Open Source, so feel free to contribute !
-================================================
-`
-
-	fmt.Println(asciiArt)
-
 	// set Flags
 	options := flags{}
 	options.setOption(os.Args[1:])
@@ -46,7 +26,7 @@ Open Source, so feel free to contribute !
 		log.Fatal(er)
 	}
 
-	customDebug.Debug("*** INFO *** options.optionalFlags ", options.optionalFlags)
+	customDebug.Debug("*** INFO *** options.optionalFlags: ", options.optionalFlags)
 
 	// check flags are set according to rules
 	options.checkFlags()
@@ -63,14 +43,14 @@ Open Source, so feel free to contribute !
 
 	for _, project := range projectIDs {
 
-		log.Println("*** INFO *** 1/4 - Retrieving Project", project)
+		log.Println("*** INFO *** Step 1/4 - Retrieving project", project)
 		projectInfo, err := getProjectDetails(options.mandatoryFlags, project, customDebug)
 		if err != nil {
 			customDebug.Debug("*** ERROR *** could not get project details. Skipping project ", project)
 			continue
 		}
 
-		log.Println("*** INFO *** 2/4 - Getting Existing JIRA tickets")
+		log.Println("*** INFO *** Step 2/4 - Retrieving a list of existing Jira tickets")
 		tickets, err := getJiraTickets(options.mandatoryFlags, project, customDebug)
 		if err != nil {
 			customDebug.Debug("*** ERROR *** could not get already existing tickets details. Skipping project ", project)
@@ -79,7 +59,7 @@ Open Source, so feel free to contribute !
 
 		customDebug.Debug("*** INFO *** List of already existing tickets: ", tickets)
 
-		log.Println("*** INFO *** 3/4 - Getting vulns")
+		log.Println("*** INFO *** Step 3/4 - Getting vulns")
 		vulnsPerPath, skippedIssues, err := getVulnsWithoutTicket(options, project, maturityFilter, tickets, customDebug)
 		if err != nil {
 			customDebug.Debug("*** ERROR *** could not vulnerability details. Skipping project ", project)
@@ -94,17 +74,17 @@ Open Source, so feel free to contribute !
 		}
 
 		if len(vulnsPerPath) == 0 {
-			log.Println("*** INFO *** 4/4 - No new JIRA ticket required")
+			log.Println("*** INFO *** Step 4/4 - No new Jira ticket required")
 		} else {
-			log.Println("*** INFO *** 4/4 - Opening JIRA Tickets")
+			log.Println("*** INFO *** Step 4/4 - Opening Jira tickets")
 			numberIssueCreated, jiraResponse, notCreatedJiraIssues, projectsTickets = openJiraTickets(options, projectInfo, vulnsPerPath, customDebug)
 			if jiraResponse == "" && !options.optionalFlags.dryRun {
-				log.Println("*** ERROR *** Failure to create a ticket(s)")
+				log.Println("*** ERROR *** Failed to create Jira ticket(s)")
 			}
 			if options.optionalFlags.dryRun {
 				fmt.Printf("\n----------PROJECT ID %s----------\n Dry run mode: no issue created\n------------------------------------------------------------------------\n", project)
 			} else {
-				fmt.Printf("\n----------PROJECT ID %s---------- \n Number of tickets created: %d\n List of issueId for which the ticket could not be created: %s\n-------------------------------------------------------------------\n", project, numberIssueCreated, notCreatedJiraIssues)
+				fmt.Printf("\n----------PROJECT ID %s---------- \n Number of tickets created: %d\n List of issueIds for which Jira ticket(s) could not be created: %s\n-------------------------------------------------------------------\n", project, numberIssueCreated, notCreatedJiraIssues)
 			}
 
 			// Adding new project tickets detail to logfile struct

--- a/snyk.go
+++ b/snyk.go
@@ -8,17 +8,18 @@ import (
 )
 
 func getOrgProjects(Mf MandatoryFlags, customDebug debug) (jsn.Json, error) {
-	responseData, err := makeSnykAPIRequest("GET", Mf.endpointAPI+"/v1/org/"+Mf.orgID+"/projects", Mf.apiToken, nil, customDebug)
+	var projectsAPI =  Mf.endpointAPI+"/v1/org/"+Mf.orgID+"/projects";
+	responseData, err := makeSnykAPIRequest("GET", projectsAPI, Mf.apiToken, nil, customDebug)
 	if err != nil {
-		log.Printf("*** ERROR *** Could not get the Project(s) for endpoint %s\n", Mf.endpointAPI)
-		errorMessage := "Failure, Could not get the Project(s) for endpoint " + Mf.endpointAPI + "\n"
+		log.Printf("*** ERROR *** Could not get the Project(s) for endpoint %s\n", projectsAPI)
+		errorMessage := "Failure, Could not get the Project(s) for endpoint " + projectsAPI + "\n"
 		err = errors.New(errorMessage)
 	}
 
 	project, err := jsn.NewJson(responseData)
 	if err != nil {
-		log.Printf("*** ERROR *** Could not get read the response from endpoint %s\n", Mf.endpointAPI)
-		errorMessage := "Failure, Could not get read the response from endpoint " + Mf.endpointAPI + "\n"
+		log.Printf("*** ERROR *** Could not get read the response from endpoint %s\n", projectsAPI)
+		errorMessage := "Failure, Could not get read the response from endpoint " + projectsAPI + "\n"
 		err = errors.New(errorMessage)
 	}
 
@@ -29,7 +30,7 @@ func getProjectsIds(options flags, customDebug debug) ([]string, error) {
 
 	var projectId []string
 	if len(options.optionalFlags.projectID) == 0 {
-		log.Println("*** INFO *** Project ID not specified - importing all projects")
+		log.Println("*** INFO *** Project ID not specified, importing all projects")
 
 		projects, err := getOrgProjects(options.mandatoryFlags, customDebug)
 

--- a/utils.go
+++ b/utils.go
@@ -173,11 +173,11 @@ func (opt *flags) setOption(args []string) {
 		v.AddConfigPath(".")
 	}
 
-	configFile := CheckConfigFileFormat(*configFilePtr)
+	configFile, configFileLocation := CheckConfigFileFormat(*configFilePtr)
 
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			fmt.Println("*** ERROR *** config file not found")
+			fmt.Println("*** WARN *** Config file is not found or maybe empty at location:", configFileLocation)
 		} else {
 			fmt.Println("*** ERROR *** ", err)
 		}
@@ -202,10 +202,9 @@ func (opt *flags) setOption(args []string) {
 Function checkMandatoryAreSet
 exit if the mandatory flags are missing
 ***/
-func (Mf *MandatoryFlags) checkMandatoryAreSet() {
-	if len(Mf.orgID) == 0 || len(Mf.apiToken) == 0 || (len(Mf.jiraProjectID) == 0 && len(Mf.jiraProjectKey) == 0) {
-		log.Println("*** ERROR *** Missing mandatory flags", Mf)
-		pflag.PrintDefaults()
+func (flags *MandatoryFlags) checkMandatoryAreSet() {
+	if len(flags.orgID) == 0 || len(flags.apiToken) == 0 || (len(flags.jiraProjectID) == 0 && len(flags.jiraProjectKey) == 0) {
+		log.Println("*** ERROR *** Missing required flag(s). Please ensure orgID, token, jiraProjectID or jiraProjectKey are set.")
 		os.Exit(1)
 	}
 }
@@ -440,7 +439,7 @@ input path string, path to the config file
 return []byte config file
 Try to read the yaml file. If this fails the config file is not valid yaml
 ***/
-func CheckConfigFileFormat(path string) []byte {
+func CheckConfigFileFormat(path string)([]byte, string) {
 
 	if len(path) == 0 {
 		path = "."
@@ -450,9 +449,8 @@ func CheckConfigFileFormat(path string) []byte {
 
 	yamlFile, err := ioutil.ReadFile(file)
 	if err != nil {
-		log.Println("*** ERROR *** Could not read config file", err)
-		log.Println("*** ERROR *** Please check the format config file", err)
+		fmt.Printf("*** ERROR *** Could not read config file at location: %s. Please ensure the file exists and is formatted correctly.\nERROR: %s\n", file, err.Error())
 	}
 
-	return yamlFile
+	return yamlFile, file
 }

--- a/vulns.go
+++ b/vulns.go
@@ -91,7 +91,7 @@ func getVulnsWithoutTicket(flags flags, projectID string, maturityFilter []strin
 
 	// IAC issues are of type configuration and are not supported atm
 	if issueType == "configuration" {
-		customDebug.Debug(" *** INFO *** IAC projects are not supported by this tool, skipping this project")
+		customDebug.Debug(" *** WARN *** IAC projects are not supported, skipping")
 		return vulnsWithAllPaths, "", err
 	}
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
- Mark all debug output as `DEBUG`
- Improve error messages and display the raw failed reason where available + share which API was called on failure.