### PR TITLE
fix: show custom field name in errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,16 +254,18 @@ Mandatory fields:
 
 
 Custom fields:
-  - At the moment we are supporting 3 types of custom fields: labels, MultiGroupPicker and MultiSelect.
-  - Make sure to respect the format belong in the config file:
-    - labels:
-      ``` "customfield_10601": jiraValue-label-Value1,Value2``` => ``` "customfield_10601":["Value1","Value2"]```
-    - MultiGroupPicker:
-      ``` "customfield_10601": jiraValue-MultiGroupPicker-Value1,Value2``` => ``` "customfield_10601":[{"name":"Value1"},{"name":"Value2"}]```
-    - MultiGroupPicker:
-      ``` "customfield_10601": jiraValue-MultiSelect-Value1,Value2```  => ``` "customfield_10601":[{"value":"Value1"},{"value":"Value2"}]```
 
-For more details on jira custom field please visit [Jira documentation] (https://developer.atlassian.com/server/jira/platform/jira-rest-api-example-create-issue-7897248/)
+At the moment we are supporting 3 types of custom Jira fields: [`labels`](https://developer.atlassian.com/server/jira/platform/jira-rest-api-example-create-issue-7897248/), [`MultiGroupPicker`](https://developer.atlassian.com/server/jira/platform/jira-rest-api-example-create-issue-7897248/) and [`MultiSelect`](https://developer.atlassian.com/server/jira/platform/jira-rest-api-example-create-issue-7897248/).
+
+Make sure to respect the format in the config file:
+- labels:
+  ``` "customfield_10601": jiraValue-label-Value1,Value2``` will be sent as ``` "customfield_10601":["Value1","Value2"]```
+- MultiGroupPicker:
+  ``` "customfield_10601": jiraValue-MultiGroupPicker-Value1,Value2``` will be sent as ``` "customfield_10601":[{"name":"Value1"},{"name":"Value2"}]```
+- MultiGroupPicker:
+  ``` "customfield_10601": jiraValue-MultiSelect-Value1,Value2``` will be sent as ``` "customfield_10601":[{"value":"Value1"},{"value":"Value2"}]```
+
+For more details on jira custom field please visit [Jira documentation](https://developer.atlassian.com/server/jira/platform/jira-rest-api-example-create-issue-7897248/)
 
 ```
 schema: 1

--- a/jira_utils.go
+++ b/jira_utils.go
@@ -215,12 +215,12 @@ func addMandatoryFieldToTicket(ticket []byte, customMandatoryField map[string]in
 
 	marshalledFieldFromTicket, _ := json.Marshal(fieldFromTicket)
 	if err != nil {
-		customDebug.Debug("*** ERROR *** Could not marshall ticket fields, mandatory fields will no the added ", err)
+		customDebug.Debug("*** ERROR *** Could not parse Jira fields config, mandatory fields will no the added ", err)
 	}
 
 	err = json.Unmarshal(marshalledFieldFromTicket, &fields)
 	if err != nil {
-		customDebug.Debug("*** ERROR *** Could not unMarshalled ticket fields, mandatory fields will no the added ", err)
+		customDebug.Debug("*** ERROR *** Could not Jira fields config, mandatory fields will no the added ", err)
 	}
 
 	for i, s := range customMandatoryField {
@@ -234,7 +234,7 @@ func addMandatoryFieldToTicket(ticket []byte, customMandatoryField map[string]in
 				}
 			}
 		} else {
-			customDebug.Debug(fmt.Sprintf("*** ERROR *** Assertion error expected map[string]interface{} but got type %T ", s))
+			customDebug.Debug(fmt.Sprintf("*** ERROR *** Expected mandatory Jira fields configuration to be in format map[string]interface{}, received type: %T for field %s ", s, i))
 		}
 
 		fields[i] = s
@@ -242,12 +242,12 @@ func addMandatoryFieldToTicket(ticket []byte, customMandatoryField map[string]in
 
 	newTicket["fields"] = fields
 
-	newMarchalledTicket, err := json.Marshal(newTicket)
+	newMarshalledTicket, err := json.Marshal(newTicket)
 	if err != nil {
-		customDebug.Debug("*** ERROR *** Could not Marshalled new ticket, mandatory fields will no the added ", err)
+		customDebug.Debug("*** ERROR *** Invalid JSON, mandatory Jira fields will be skipped. ERROR:", err)
 	}
 
-	return newMarchalledTicket
+	return newMarshalledTicket
 }
 
 /***

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 			continue
 		}
 
-		customDebug.Debug("*** INFO *** List of vuln without tickets: ", vulnsPerPath)
+		customDebug.Debug("*** INFO *** # of vulns without tickets: ", len(vulnsPerPath))
 
 		if len(skippedIssues) > 0 {
 			customDebug.Debug("*** INFO *** List of skipped vulns: ", skippedIssues)

--- a/utils.go
+++ b/utils.go
@@ -195,6 +195,7 @@ func (opt *flags) setOption(args []string) {
 	// needed to open a jira ticket
 	// don't do something not needed
 	if v.Get("jira.customMandatoryFields") != nil {
+		log.Println("*** INFO *** Detected custom Jira fields configuration, trying to parse the data")
 		opt.customMandatoryJiraFields = findCustomJiraMandatoryFlags(configFile)
 	}
 
@@ -378,7 +379,6 @@ input: none
 Read the config file and extract the jira fields than the mandatory field inside it
 ***/
 func findCustomJiraMandatoryFlags(yamlFile []byte) map[string]interface{} {
-
 	config := make(map[interface{}]interface{})
 	yamlCustomJiraMandatoryField := make(map[interface{}]interface{})
 	jsonCustomJiraMandatoryField := make(map[string]interface{})


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
- print out the custom Jira field name if it is unexpected format
- Skip printing whole vuln data, stick to # or the title

