### PR TITLE
Docs/fix labels example

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ jira:
     assigneeId: 123abc456def789
     assigneeName: AccountName
     priorityIsSeverity: true # <true|false>
-    label: label1 # <IssueLabel1>,<IssueLabel2>
+    labels: label1 # <IssueLabel1>,<IssueLabel2>
     jiraProjectKey: testProject
     priorityIsSeverity: false # <true|false> (defaults: Low|Medium|High|Critical=>Low|Medium|High|Highest)
     customMandatoryFields:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
The example should have said `labels` instead of `label` as `label` will not work