### PR TITLE
minor: add more error handling to avoid segfault

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -237,6 +237,10 @@ func HTTPResponseCheckOpenJiraTicketsWithError50x(url string) *httptest.Server {
 			fmt.Println("Working case")
 			w.WriteHeader(http.StatusAccepted)
 			resp = readFixture("./fixtures/singleJiraTicketOpeningResponse.json")
+		} else if count == 1 {
+			fmt.Println("Error case no status")
+			resp = nil
+			count++
 		} else {
 			fmt.Println("Error case")
 			w.WriteHeader(503)


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

I think the problem was that the response from a request can be nil, we weren't handling that.
I added checks to avoid trying to do anything if the response is nil and do a retry instead. 

### Notes for the reviewer

I did manage to reproduce the issue twice. last try the tool ran fine.

### More information

- [Link to documentation](https://github.com/snyk-tech-services/jira-tickets-for-new-vulns/wiki/)

### Screenshots

tested with ./jira-tickets-for-new-vulns --token=$SNYK_TOKEN --orgID=71281f6e-0bb2-41de-8a3d-e80d9ad4faa5 --projectID=80e0d19e-93f1-4bd0-b5be-a593b6afc03c --jiraProjectKey=TESTMAT --debug=true

<img width="635" alt="Image" src="https://user-images.githubusercontent.com/82386195/183141811-5a0a9ced-fc32-4220-8490-74b01587e949.png">

