### PR TITLE
feat: add a log if we skip an issue when it is not upgradable

### DIFF
--- a/jira.go
+++ b/jira.go
@@ -221,6 +221,7 @@ func openJiraTickets(flags flags, projectInfo jsn.Json, vulnsForJira map[string]
 		// skip ticket creating if the vuln is not upgradable
 		if flags.optionalFlags.ifUpgradeAvailableOnly {
 			if jsonVuln.K("fixInfo").K("isUpgradable").Bool().Value == false {
+				log.Printf("*** INFO *** Skipping creating a Jira issue because no upgrade is available. Vuln: %s", jsonVuln.K("issueData").K("title").String().Value)
 				continue
 			}
 		}


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Sometimes it seems we simply do not open a Jira issue without explaining why in the output, I suspect this is where this happens so adding an output here.
