### PR TITLE
Add optional argument to suffix CVE to Jira summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ Use `go install github.com/snyk-tech-services/jira-tickets-for-new-vulns@latest`
 
   *Example*: `--debug=true`
 
+- `--cveInTitle` *optional*
+
+  Enables the CVEs as suffix in the Jira ticket title.
+
+  *Example*: `--cveInTitle=true`
+
 - `--ifUpgradeAvailableOnly` *optional*
 
   Only create tickets for `vuln` issues that are upgradable.`--type` must be set to `all` or `vuln` for this to work.

--- a/fixtures/vulnForJiraAggregatedWithPath.json
+++ b/fixtures/vulnForJiraAggregatedWithPath.json
@@ -50,4 +50,3 @@
     "from" : [[{"name":"snyk","version":"1.228.3"},{"name":"proxy-agent","version":"3.1.0"},{"name":"pac-proxy-agent","version":"3.0.0"},{"name":"pac-resolver","version":"3.0.0"}]]
   }
 }
-

--- a/formatTicket_test.go
+++ b/formatTicket_test.go
@@ -17,7 +17,9 @@ func TestFormatJiraTicketFunc(t *testing.T) {
 	projectInfo, _ := jsn.NewJson(readFixture("./fixtures/project.json"))
 	issueData, _ := jsn.NewJson(readFixture("./fixtures/vulnForJiraAggregatedWithPathForTicketTest.json"))
 
-	jiraTicket := formatJiraTicket(issueData, projectInfo)
+	flags := optionalFlags{}
+
+	jiraTicket := formatJiraTicket(issueData, projectInfo, flags)
 
 	// Convert jira ticket into a string
 	ticket := fmt.Sprintf("%v", jiraTicket)
@@ -32,7 +34,6 @@ func TestFormatJiraTicketFunc(t *testing.T) {
 
 	for scanner.Scan() {
 		compare := strings.Contains(ticket, scanner.Text())
-		//fmt.Println(scanner.Text())
 		assert.Equal(t, compare, true)
 	}
 

--- a/jira.go
+++ b/jira.go
@@ -101,7 +101,7 @@ func openJiraTicket(flags flags, projectInfo jsn.Json, vulnForJira interface{}, 
 		jiraTicket = formatCodeJiraTicket(jsonVuln, projectInfo)
 		vulnID = jsonVuln.K("data").K("id").String().Value
 	} else {
-		jiraTicket = formatJiraTicket(jsonVuln, projectInfo)
+		jiraTicket = formatJiraTicket(jsonVuln, projectInfo, flags.optionalFlags)
 	}
 
 	if len(vulnID) == 0 {

--- a/utils.go
+++ b/utils.go
@@ -88,7 +88,7 @@ Function setOption
 set the optional flags structure
 **
 */
-func (Of *optionalFlags) setoptionalFlags(debugPtr bool, dryRunPtr bool, v viper.Viper) {
+func (Of *optionalFlags) setoptionalFlags(debugPtr bool, dryRunPtr bool, cveInTitlePtr bool, v viper.Viper) {
 
 	Of.projectID = v.GetString("snyk.projectID")
 	Of.projectCriticality = v.GetString("snyk.projectCriticality")
@@ -104,6 +104,7 @@ func (Of *optionalFlags) setoptionalFlags(debugPtr bool, dryRunPtr bool, v viper
 	Of.priorityScoreThreshold = v.GetInt("snyk.priorityScoreThreshold")
 	Of.debug = debugPtr
 	Of.dryRun = dryRunPtr
+	Of.cveInTitle = cveInTitlePtr
 	Of.ifUpgradeAvailableOnly = v.GetBool("snyk.ifUpgradeAvailableOnly")
 }
 
@@ -133,6 +134,7 @@ func (opt *flags) setOption(args []string) {
 	var apiTokenPtr *string
 	var debugPtr *bool
 	var dryRunPtr *bool
+	var cveInTitlePtr *bool
 	var configFilePtr *string
 
 	// Using viper to bind config file and flags
@@ -160,6 +162,7 @@ func (opt *flags) setOption(args []string) {
 	fs.Int("priorityScoreThreshold", 0, "Optional. Your min priority score threshold [INT between 0 and 1000]")
 	debugPtr = fs.Bool("debug", false, "Optional. Boolean. enable debug mode")
 	dryRunPtr = fs.Bool("dryRun", false, "Optional. Boolean. create a file with all the tickets without open them on jira")
+	cveInTitlePtr = fs.Bool("cveInTitle", false, "Optional. Boolean. adds the CVEs to the jira ticket title")
 	fs.Bool("ifUpgradeAvailableOnly", false, "Optional. Boolean. Open tickets only for upgradable issues")
 	configFilePtr = fs.String("configFile", "", "Optional. Config file path. Use config file to set parameters")
 	fs.Parse(args)
@@ -210,7 +213,7 @@ func (opt *flags) setOption(args []string) {
 
 	// Setting the flags structure
 	opt.mandatoryFlags.setMandatoryFlags(apiTokenPtr, *v)
-	opt.optionalFlags.setoptionalFlags(*debugPtr, *dryRunPtr, *v)
+	opt.optionalFlags.setoptionalFlags(*debugPtr, *dryRunPtr, *cveInTitlePtr, *v)
 
 	// check the flags rules
 	opt.checkFlags()
@@ -241,7 +244,7 @@ To work properly with jira these needs to be respected:
 */
 func (flags *flags) checkFlags() {
 	if flags.mandatoryFlags.jiraProjectID != "" && flags.mandatoryFlags.jiraProjectKey != "" {
-		log.Fatalf(("*** ERROR *** You passed both jiraProjectID and jiraProjectKey in parameters\n Please, Use jiraProjectID OR jiraProjectKey, not both"))
+		log.Fatalf("*** ERROR *** You passed both jiraProjectID and jiraProjectKey in parameters\n Please, Use jiraProjectID OR jiraProjectKey, not both")
 	}
 
 	if flags.optionalFlags.priorityScoreThreshold < 0 || flags.optionalFlags.priorityScoreThreshold > 1000 {
@@ -257,6 +260,7 @@ argument: debug
 Check if the file exist if not create it
 **
 */
+
 func CreateLogFile(customDebug debug, fileType string) string {
 
 	// Get date

--- a/utils_def.go
+++ b/utils_def.go
@@ -37,5 +37,6 @@ type optionalFlags struct {
 	priorityScoreThreshold int
 	debug                  bool
 	dryRun                 bool
+	cveInTitle             bool
 	ifUpgradeAvailableOnly bool
 }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds an optional flag to append the CVE list to the Jira summary 
This is often request of compliance team to have the information pulled out of the body in order to facilitate exports of Jira data for audit purposes

### Notes for the reviewer

Simply a new optional flag, without it nothing changes

### Screenshots

_Visuals that may help the reviewer_
