### PR TITLE
minor: Adding new flag: canAutoPR

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ Use `go install github.com/snyk-tech-services/jira-tickets-for-new-vulns@latest`
 
   *Example*: `--configFile=/directory-name`
 
+- `--ifAutoFixableOnly` *optional*
+
+  Only create tickets for `vuln` issues that are fixable (no effect when using `ifUpgradeAvailableOnly`).`--type` must be set to `all` or `vuln` for this to work.
+
+  *Example*: `--ifAutoFixableOnly=true`
+
 ## Restrictions
 The tool does not support IAC project. It will open issue only for code and open source projects and ignore all other project type.
 

--- a/fixtures/vulnForJiraAggregatedWithPathList2.json
+++ b/fixtures/vulnForJiraAggregatedWithPathList2.json
@@ -89,7 +89,6 @@
     "isIgnored": false,
     "fixInfo": {
       "isUpgradable": false,
-      "isFixable": true,
       "isPinnable": false,
       "isPatchable": false,
       "isPartiallyFixable": true,

--- a/fixtures/yamlFileForMandatoryFieldTest/jira.yaml
+++ b/fixtures/yamlFileForMandatoryFieldTest/jira.yaml
@@ -6,6 +6,7 @@ snyk:
     type: vuln #what snyk issue types should we consider to ticket
     priorityScoreThreshold: 20
     ifUpgradeAvailableOnly: true
+    ifAutoFixableOnly: true
 jira:
     jiraTicketType: Task
     jiraProjectID: 15698

--- a/jira.go
+++ b/jira.go
@@ -224,7 +224,7 @@ func displayErrorForIssue(vulnForJira interface{}, reason string, error error, e
 	jsonVuln, _ := jsn.NewJson(vulnForJira)
 	vulnID := jsonVuln.K("id").String().Value
 	message := fmt.Sprintf("VulnID %s ticket not created : Request to %s failed with : %s", vulnID, endpointAPI, error)
-	if reason == "ifUpgradeAvailableOnly" {
+	if reason == "ifUpgradeAvailableOnly" || reason == "ifAutoFixableOnly" {
 		message = fmt.Sprintf("VulnID %s ticket not created : %s", vulnID, error)
 	}
 	log.Printf("*** ERROR *** " + message)
@@ -248,6 +248,13 @@ func openJiraTickets(flags flags, projectInfo jsn.Json, vulnsForJira map[string]
 			if jsonVuln.K("fixInfo").K("isUpgradable").Bool().Value == false {
 				message := fmt.Sprintf("Skipping creating ticket for %s because no upgrade is available.", jsonVuln.K("issueData").K("title").String().Value)
 				fullListNotCreatedIssue += displayErrorForIssue(vulnForJira, "ifUpgradeAvailableOnly", errors.New(message), "", customDebug)
+				continue
+			}
+		} else if flags.optionalFlags.ifAutoFixableOnly {
+			// skip ticket creating if the vuln is not fixable
+			if jsonVuln.K("fixInfo").K("isFixable").Bool().Value == false {
+				message := fmt.Sprintf("Skipping creating ticket for %s because no fix is available.", jsonVuln.K("issueData").K("title").String().Value)
+				fullListNotCreatedIssue += displayErrorForIssue(vulnForJira, "ifAutoFixableOnly", errors.New(message), "", customDebug)
 				continue
 			}
 		}

--- a/jira_labels_test.go
+++ b/jira_labels_test.go
@@ -77,6 +77,7 @@ func TestOpenJiraTicketWithLabelsFunc(t *testing.T) {
 	Of.dryRun = false
 	Of.cveInTitle = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -137,6 +138,7 @@ func TestOpenJiraTicketWithoutLabelsFunc(t *testing.T) {
 	Of.dryRun = false
 	Of.cveInTitle = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf

--- a/jira_prioritymapping_test.go
+++ b/jira_prioritymapping_test.go
@@ -48,6 +48,7 @@ func TestOpenJiraTicketWithPriorityMappingFunc(t *testing.T) {
 	Of.dryRun = false
 	Of.cveInTitle = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -108,6 +109,7 @@ func TestOpenJiraTicketWithoutPriorityMappingFunc(t *testing.T) {
 	Of.dryRun = false
 	Of.cveInTitle = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -170,6 +172,7 @@ func TestOpenJiraTicketWithCustomPriorityMappingFunc(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf

--- a/jira_snyk_code_test.go
+++ b/jira_snyk_code_test.go
@@ -39,6 +39,7 @@ func TestFormatCodeTicketFunc(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -106,6 +107,7 @@ func TestOpenJiraTicketCodeOnly(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -165,6 +167,7 @@ func TestOpenJiraTicketCodeOnlyWithLabel(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -229,6 +232,7 @@ func TestOpenJiraTicketCodeOnlyWithSeverity(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -294,6 +298,7 @@ func TestOpenJiraTicketCodeOnlyWithAssigneeId(t *testing.T) {
 	Of.dryRun = false
 	Of.cveInTitle = true
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -353,6 +358,7 @@ func TestGetSnykCodeIssueWithoutTickets(t *testing.T) {
 	Of.projectID = ""
 	Of.maturityFilterString = ""
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -410,6 +416,7 @@ func TestGetSnykCodeIssueWithoutTicketsWithIgnored(t *testing.T) {
 	Of.projectID = ""
 	Of.maturityFilterString = ""
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -467,6 +474,7 @@ func TestGetSnykCodeIssueWithoutTicketsWithSeverityFilter(t *testing.T) {
 	Of.projectID = ""
 	Of.maturityFilterString = ""
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -522,6 +530,7 @@ func TestGetSnykCodeIssueWithoutTicketsWithPagination(t *testing.T) {
 	Of.projectID = "xxx99a85-c519-xxxx-ae55-xxx9b9bfaxxx"
 	Of.maturityFilterString = ""
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf

--- a/jira_test.go
+++ b/jira_test.go
@@ -48,6 +48,7 @@ func TestOpenJiraTicketFunc(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -102,6 +103,7 @@ func TestOpenJiraTicketWithProjectKeyFunc(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -156,6 +158,7 @@ func TestOpenJiraTicketErrorAndRetryFunc(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -214,6 +217,7 @@ func TestOpenJiraMultipleTicketsErrorAndRetryFunc(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -288,6 +292,7 @@ func TestOpenJiraMultipleTicketsErrorAndRetryAndFailFunc(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -363,6 +368,7 @@ func TestOpenJiraMultipleTicketsFailureFunc(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -439,6 +445,7 @@ func TestOpenJiraTicketWithAssigneeIDFunc(t *testing.T) {
 	Of.dryRun = false
 	Of.cveInTitle = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -503,6 +510,7 @@ func TestOpenJiraTicketDryRun(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = true
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -561,6 +569,7 @@ func TestOpenJiraMultipleTicketsIsUpgradableFunc(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = true
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -576,6 +585,158 @@ func TestOpenJiraMultipleTicketsIsUpgradableFunc(t *testing.T) {
 	fmt.Println(NotCreatedIssueId)
 	assert.NotNil(tickets)
 	assert.Equal("VulnID SNYK-JS-MINIMIST-559765 ticket not created : Skipping creating ticket for Remote Code Execution (RCE) because no upgrade is available.", NotCreatedIssueId)
+	assert.Equal(NumberIssueCreated, 1)
+
+	// Read fixture file line by line
+	file, err := os.Open("./fixtures/results/jiraMultipleTicketsOpeningResultsIsUpgradable")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	// assert if the line is not in the jira response
+	for scanner.Scan() {
+		assert.Contains(jiraResponse, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		panic(err)
+	}
+
+	// Delete the file created for the test
+	removeLogFile()
+
+	return
+}
+
+func TestOpenJiraMultipleTicketsifAutoFixableOnlyFunc(t *testing.T) {
+	assert := assert.New(t)
+	server := HTTPResponseCheckOpenJiraMultipleTickets()
+
+	defer server.Close()
+
+	projectInfo, _ := jsn.NewJson(readFixture("./fixtures/project.json"))
+	vulnsForJira := make(map[string]interface{})
+	err := json.Unmarshal(readFixture("./fixtures/vulnForJiraAggregatedWithPathList.json"), &vulnsForJira)
+	if err != nil {
+		panic(err)
+	}
+
+	// setting mandatory options
+	Mf := MandatoryFlags{}
+	Mf.orgID = "123"
+	Mf.endpointAPI = server.URL
+	Mf.apiToken = "123"
+	Mf.jiraProjectID = "123"
+	Mf.jiraProjectKey = ""
+
+	// setting optional options
+	Of := optionalFlags{}
+	Of.severity = ""
+	Of.priorityScoreThreshold = 0
+	Of.issueType = ""
+	Of.debug = false
+	Of.jiraTicketType = "Bug"
+	Of.assigneeID = ""
+	Of.labels = ""
+	Of.priorityIsSeverity = true
+	Of.projectID = ""
+	Of.maturityFilterString = ""
+	Of.dryRun = false
+	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = true
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
+	// setting debug
+	cD := debug{}
+	cD.setDebug(false)
+	CreateLogFile(cD, "ErrorsFile_")
+
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId, tickets := openJiraTickets(flags, projectInfo, vulnsForJira, cD)
+
+	fmt.Println(NotCreatedIssueId)
+	assert.NotNil(tickets)
+	assert.Equal("", NotCreatedIssueId)
+	assert.Equal(NumberIssueCreated, 2)
+
+	// Read fixture file line by line
+	file, err := os.Open("./fixtures/results/jiraMultipleTicketsOpeningResultsIsUpgradable")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	// assert if the line is not in the jira response
+	for scanner.Scan() {
+		assert.Contains(jiraResponse, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		panic(err)
+	}
+
+	// Delete the file created for the test
+	removeLogFile()
+
+	return
+}
+
+func TestOpenJiraSingleTicketIfAutoFixableOnlyFunc(t *testing.T) {
+	assert := assert.New(t)
+	server := HTTPResponseCheckOpenJiraMultipleTickets()
+
+	defer server.Close()
+
+	projectInfo, _ := jsn.NewJson(readFixture("./fixtures/project.json"))
+	vulnsForJira := make(map[string]interface{})
+	err := json.Unmarshal(readFixture("./fixtures/vulnForJiraAggregatedWithPathList2.json"), &vulnsForJira)
+	if err != nil {
+		panic(err)
+	}
+
+	// setting mandatory options
+	Mf := MandatoryFlags{}
+	Mf.orgID = "123"
+	Mf.endpointAPI = server.URL
+	Mf.apiToken = "123"
+	Mf.jiraProjectID = "123"
+	Mf.jiraProjectKey = ""
+
+	// setting optional options
+	Of := optionalFlags{}
+	Of.severity = ""
+	Of.priorityScoreThreshold = 0
+	Of.issueType = ""
+	Of.debug = false
+	Of.jiraTicketType = "Bug"
+	Of.assigneeID = ""
+	Of.labels = ""
+	Of.priorityIsSeverity = true
+	Of.projectID = ""
+	Of.maturityFilterString = ""
+	Of.dryRun = false
+	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = true
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
+	// setting debug
+	cD := debug{}
+	cD.setDebug(false)
+	CreateLogFile(cD, "ErrorsFile_")
+
+	NumberIssueCreated, jiraResponse, NotCreatedIssueId, tickets := openJiraTickets(flags, projectInfo, vulnsForJira, cD)
+
+	fmt.Println(NotCreatedIssueId)
+	assert.NotNil(tickets)
+	assert.Equal("VulnID SNYK-JS-MINIMIST-559765 ticket not created : Skipping creating ticket for Remote Code Execution (RCE) because no fix is available.", NotCreatedIssueId)
 	assert.Equal(NumberIssueCreated, 1)
 
 	// Read fixture file line by line
@@ -638,6 +799,7 @@ func TestOpenJiraTicketDryRyn(t *testing.T) {
 	Of.dryRun = true
 	Of.cveInTitle = true
 	Of.ifUpgradeAvailableOnly = true
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -657,6 +819,68 @@ func TestOpenJiraTicketDryRyn(t *testing.T) {
 	assert.Equal(jiraResponse, "")
 	assert.Equal(numberIssueCreated, 0)
 	assert.Equal(NotCreatedIssueId, "")
+
+	return
+
+}
+
+func TestOpenJiraTicketDryRunifAutoFixableOnly(t *testing.T) {
+
+	assert := assert.New(t)
+	server := HTTPResponseStubAndMirrorRequest("/v1/org/123/project/12345678-1234-1234-1234-123456789012/issue/SNYK-JS-MINIMIST-559764/jira-issue", "", "")
+
+	defer server.Close()
+
+	projectInfo, _ := jsn.NewJson(readFixture("./fixtures/project.json"))
+	vulnsForJira := make(map[string]interface{})
+	err := json.Unmarshal(readFixture("./fixtures/vulnForJiraAggregatedWithPath.json"), &vulnsForJira)
+	if err != nil {
+		panic(err)
+	}
+
+	// setting mandatory options
+	Mf := MandatoryFlags{}
+	Mf.orgID = "123"
+	Mf.endpointAPI = server.URL
+	Mf.apiToken = "123"
+	Mf.jiraProjectID = "123"
+	Mf.jiraProjectKey = ""
+
+	// setting optional options
+	Of := optionalFlags{}
+	Of.severity = ""
+	Of.priorityScoreThreshold = 0
+	Of.issueType = ""
+	Of.debug = false
+	Of.jiraTicketType = "Bug"
+	Of.assigneeID = ""
+	Of.labels = ""
+	Of.priorityIsSeverity = true
+	Of.projectID = ""
+	Of.maturityFilterString = ""
+	Of.dryRun = true
+	Of.cveInTitle = true
+	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = true
+
+	flags := flags{}
+	flags.mandatoryFlags = Mf
+	flags.optionalFlags = Of
+
+	// setting debug
+	cD := debug{}
+	cD.setDebug(false)
+
+	CreateLogFile(cD, "ErrorsFile_")
+
+	numberIssueCreated, jiraResponse, NotCreatedIssueId, tickets := openJiraTickets(flags, projectInfo, vulnsForJira, cD)
+
+	removeLogFile()
+
+	assert.NotNil(tickets)
+	assert.Equal(jiraResponse, "")
+	assert.Equal(numberIssueCreated, 0)
+	assert.Equal(NotCreatedIssueId, "VulnID SNYK-JS-MINIMIST-559764 ticket not created : Skipping creating ticket for Remote Code Execution (RCE) because no fix is available.")
 
 	return
 
@@ -800,6 +1024,7 @@ func TestOpenJiraTicketError50xAndRetryFunc(t *testing.T) {
 	Of.maturityFilterString = ""
 	Of.dryRun = false
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf

--- a/utils.go
+++ b/utils.go
@@ -106,6 +106,7 @@ func (Of *optionalFlags) setOptionalFlags(debugPtr bool, dryRunPtr bool, v viper
 	Of.dryRun = dryRunPtr
 	Of.cveInTitle = v.GetBool("jira.cveInTitle")
 	Of.ifUpgradeAvailableOnly = v.GetBool("snyk.ifUpgradeAvailableOnly")
+	Of.ifAutoFixableOnly = v.GetBool("snyk.ifAutoFixableOnly")
 }
 
 /*
@@ -163,6 +164,7 @@ func (opt *flags) setOption(args []string) {
 	dryRunPtr = fs.Bool("dryRun", false, "Optional. Boolean. Creates a file with all the tickets without open them on jira")
 	fs.Bool("cveInTitle", false, "Optional. Boolean. Adds the CVEs to the jira ticket title")
 	fs.Bool("ifUpgradeAvailableOnly", false, "Optional. Boolean. Opens tickets only for upgradable issues")
+	fs.Bool("ifAutoFixableOnly", false, "Optional. Boolean. Opens tickets for issues that are fixable (no effect when using ifUpgradeAvailableOnly)")
 	configFilePtr = fs.String("configFile", "", "Optional. Config file path. Use config file to set parameters")
 	fs.Parse(args)
 
@@ -187,6 +189,7 @@ func (opt *flags) setOption(args []string) {
 	v.BindPFlag("jira.priorityIsSeverity", fs.Lookup("priorityIsSeverity"))
 	v.BindPFlag("snyk.priorityScoreThreshold", fs.Lookup("priorityScoreThreshold"))
 	v.BindPFlag("snyk.ifUpgradeAvailableOnly", fs.Lookup("ifUpgradeAvailableOnly"))
+	v.BindPFlag("snyk.ifAutoFixableOnly", fs.Lookup("ifAutoFixableOnly"))
 
 	// Set and parse config file
 	v.SetConfigName("jira") // config file name without extension
@@ -598,6 +601,12 @@ func checkSnykValue(snykValues interface{}) bool {
 				return false
 			}
 		case "ifUpgradeAvailableOnly":
+			valueType := reflect.TypeOf(value).String()
+			if valueType != "bool" {
+				log.Printf("*** ERROR *** Please check the format config file, %s is of type %s when it should be a boolean", key, reflect.TypeOf(value).String())
+				return false
+			}
+		case "ifAutoFixableOnly":
 			valueType := reflect.TypeOf(value).String()
 			if valueType != "bool" {
 				log.Printf("*** ERROR *** Please check the format config file, %s is of type %s when it should be a boolean", key, reflect.TypeOf(value).String())

--- a/utils_def.go
+++ b/utils_def.go
@@ -39,4 +39,5 @@ type optionalFlags struct {
 	dryRun                 bool
 	cveInTitle             bool
 	ifUpgradeAvailableOnly bool
+	ifAutoFixableOnly      bool
 }

--- a/utils_test_test.go
+++ b/utils_test_test.go
@@ -136,6 +136,7 @@ func TestSetOption(t *testing.T) {
 		projectID:              "",
 		severity:               "critical",
 		ifUpgradeAvailableOnly: true,
+		ifAutoFixableOnly:      true,
 	}
 
 	customMandatoryJiraFields := map[string]interface{}{"Something": map[string]interface{}{"Value": "This is a summary"}, "transition": map[string]interface{}{"id": 5}}

--- a/vulns_test.go
+++ b/vulns_test.go
@@ -36,6 +36,7 @@ func TestGetVulnsWithoutTicketFunc(t *testing.T) {
 	Of.projectID = ""
 	Of.maturityFilterString = ""
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -96,6 +97,7 @@ func TestNoVulnOrLicense(t *testing.T) {
 	Of.projectID = ""
 	Of.maturityFilterString = ""
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -150,6 +152,7 @@ func TestGetVulnsWithoutTicketErrorRetrievingDataFunc(t *testing.T) {
 	Of.projectID = ""
 	Of.maturityFilterString = ""
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf
@@ -205,6 +208,7 @@ func TestGetLicenseWithoutTicketFunc(t *testing.T) {
 	Of.projectID = ""
 	Of.maturityFilterString = ""
 	Of.ifUpgradeAvailableOnly = false
+	Of.ifAutoFixableOnly = false
 
 	flags := flags{}
 	flags.mandatoryFlags = Mf


### PR DESCRIPTION

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This is to address https://github.com/snyk-tech-services/jira-tickets-for-new-vulns/issues/182, only opens issues via opt in flag if the issue is fixable by Snyk (automatically)
