### PR TITLE
fix: use public utility container for github releasing tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,7 @@ jobs:
 
   publish-github-release:
     docker:
-      - image: gcr.io/snyk-technical-services/cicd-github
-        auth:
-          username: _json_key
-          password: $GCLOUD_GCR_SNYK_TS_READER
+      - image: aarlaudsnyk/utility-containers
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Uses a now public utility container containing the github release component.