### PR TITLE
fix: restore previous priorityIsSeverity value after retry

### DIFF
--- a/jira.go
+++ b/jira.go
@@ -279,12 +279,15 @@ func openJiraTickets(flags flags, projectInfo jsn.Json, vulnsForJira map[string]
 		if !flags.optionalFlags.dryRun {
 
 			if RequestFailed == true {
+				previousPriorityIsSeverity := flags.optionalFlags.priorityIsSeverity
 				for numberOfRetries := 0; numberOfRetries < MaxNumberOfRetry; numberOfRetries++ {
 
 					customDebug.Debug("*** INFO *** Retrying with priorityIsSeverity set to false, max retries=", MaxNumberOfRetry)
 
 					flags.optionalFlags.priorityIsSeverity = false
 					responseDataAggregatedByte, ticket, err, jiraApiUrl = openJiraTicket(flags, projectInfo, vulnForJira, customDebug)
+					// restore previous priorityIsSeverity value
+					flags.optionalFlags.priorityIsSeverity = previousPriorityIsSeverity
 					if err != nil {
 						fullListNotCreatedIssue += displayErrorForIssue(vulnForJira, "api", err, jiraApiUrl, customDebug)
 					} else {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

_Explain why this PR exists_

This PR fixes an issue where the `priorityIsSeverity` value is modified for a retry attempt but is never restored to the previous value after the retry. Without this fix, any subsequent `vulnForJira` processed (for loop on line 249) may have an incorrect Jira priority value.

### Notes for the reviewer

Replicate by this scenario:
1. Use `--priorityIsSeverity=true`
1. Attempt to create multiple Jira tickets of varying priority
1. Experience an error during Jira creation 
    1. Example - the Snyk severity maps to a Jira priority that doesn't exist
1. Check priority of tickets processed and created after the error is encountered

### More information

- n/a

### Screenshots

- n/a
