### PR TITLE
minor: #212/print errors in writeErrorFile when not found

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -374,10 +374,17 @@ func writeErrorFile(function string, errorText string, customDebug debug) {
 
 	// Get filePath
 	filename, err := FindFile("ErrorsFile")
+	if err != nil {
+		workingDir, _ := os.Getwd()
+		log.Println("*** ERROR *** Could not find any ErrorsFiles in the working directory at %s", workingDir, err)
+	}
 
 	// Read the file, unMarshallto get a map[]interface{} and append the new error and Marshall to create a json
 	// ReadFile
 	jsonErrofile, _ := ReadFile(filename, false)
+	if jsonErrofile == nil {
+		log.Println("*** ERROR *** No content in ErrorsFile, could not get errors")
+	}
 
 	// unMarshall
 	err = json.Unmarshal(jsonErrofile, &errorsInterface)


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Closes #212 
Adds error messages when errorsfiles cannot be find, to make debugging effort easier in the future.

### Notes for the reviewer
Please review if the logs are written to your standards.

### More information

- [Link to documentation](https://github.com/snyk-tech-services/jira-tickets-for-new-vulns/wiki/)

### Screenshots
To add more context, as this doesn't help that much:
![325766946-a930d223-b047-4299-8f57-d41940ea114a](https://github.com/snyk-tech-services/jira-tickets-for-new-vulns/assets/15033328/0c1187f0-a2fa-4028-b277-d421c39a255c)

