### PR TITLE
minor: #211/snyk WAF error handling and sanitizing

### DIFF
--- a/jira_utils.go
+++ b/jira_utils.go
@@ -147,6 +147,10 @@ func formatJiraTicket(jsonVuln jsn.Json, projectInfo jsn.Json, flags flags) *Jir
 
 	// Build Summary
 	summary := projectInfo.K("name").String().Value + " - " + issueData.K("title").String().Value
+
+	// Sanitizing subject to prevent Path Traversal protection failure in Web Application Firewall
+	summary = strings.ReplaceAll(summary, "/bin/", "_bin_")
+
 	if flags.optionalFlags.cveInTitle == true && len(cveIdentifiers) > 0 {
 		summary = fmt.Sprintf("%s - %s", summary, strings.Join(cveIdentifiers, ", "))
 	}

--- a/snyk_utils.go
+++ b/snyk_utils.go
@@ -105,6 +105,14 @@ func makeSnykAPIRequest(verb string, endpointURL string, snykToken string, body 
 		errorMessage := fmt.Sprintf("*** INFO *** Request on endpoint '%s' failed with error %s\n", endpointURL, response.Status)
 		writeErrorFile("makeSnykAPIRequest", errorMessage, customDebug)
 		return nil, errors.New("Not found, Request failed")
+	} else if response.StatusCode == 403 {
+		customDebug.Debugf("*** INFO *** Request on endpoint '%s' failed with error %s\n", endpointURL, response.Status)
+		customDebug.Debugf("*** INFO *** Please check that all expected fields are present in the config file\n")
+		customDebug.Debugf("*** INFO *** Forbidden could indicate illegal strings in the body, such as Path Traversal\n")
+		customDebug.Debugf("*** INFO *** Details : %s\n", string(responseData))
+		errorMessage := fmt.Sprintf("*** INFO *** Request on endpoint '%s' failed with error %s\n", endpointURL, response.Status)
+		writeErrorFile("makeSnykAPIRequest", errorMessage, customDebug)
+		return nil, errors.New("Forbidden Entity, Request failed")
 	} else if response.StatusCode == 422 {
 		customDebug.Debugf("*** INFO *** Request on endpoint '%s' failed with error %s\n", endpointURL, response.Status)
 		customDebug.Debugf("*** INFO *** Please check that all expected fields are present in the config file\n")


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Closes #211
Adds a case to sanitize the summary to prevent the HTTP Error 403 forbidden, likely happening due to [Path Traversal attacks](https://owasp.org/www-community/attacks/Path_Traversal) prevention.

### Notes for the reviewer
Let me know if the INFO messages in the `else if response.StatusCode == 403` in snyk_utils.go are okay to mention the "Forbidden" warning.

### More information

- [Link to documentation](https://github.com/snyk-tech-services/jira-tickets-for-new-vulns/wiki/)

### Screenshots
