### PR TITLE
Fixing dueDate to duedate

### DIFF
--- a/jira.go
+++ b/jira.go
@@ -31,7 +31,7 @@ type Field struct {
 	Assignees   *Assignee     `json:"assignee,omitempty"`
 	Priority    *PriorityType `json:"priority,omitempty"`
 	Labels      []string      `json:"labels,omitempty"`
-	DueDate     string        `json:"dueDate,omitempty"`
+	DueDate     string        `json:"duedate,omitempty"`
 }
 
 // Assignee is the account ID of the Jira user to assign tickets to


### PR DESCRIPTION
### What this does

Fixes the builtin Jira label to be `duedate` instead of `dueDate`. This is a required field for some Jira tickets so this fix allows the proper JSON to be produced (and not have Jira complain about it). 

Fixes #201 

### Notes for the reviewer

Same testing and local setup as this change only changes capitalizing within the JSON produced

