### PR TITLE
Fix wrong usage of Println without fmt

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -376,7 +376,7 @@ func writeErrorFile(function string, errorText string, customDebug debug) {
 	filename, err := FindFile("ErrorsFile")
 	if err != nil {
 		workingDir, _ := os.Getwd()
-		log.Println("*** ERROR *** Could not find any ErrorsFiles in the working directory at %s", workingDir, err)
+		log.Println("*** ERROR *** Could not find any ErrorsFiles in the working directory at location: ", workingDir, "\n", err)
 	}
 
 	// Read the file, unMarshallto get a map[]interface{} and append the new error and Marshall to create a json


### PR DESCRIPTION
### What this does

Fixes an error introduced in #213 which caused CircleCI to fail due to an incorrect usage of log.Println("%s").
More info here: https://github.com/snyk-tech-services/jira-tickets-for-new-vulns/pull/213/files#r1656632397

### Notes for the reviewer
Very sorry about introducing an error, my apologies!