### PR TITLE
fix: Support hyphens in custom jiraValue values

### DIFF
--- a/jira_utils.go
+++ b/jira_utils.go
@@ -307,7 +307,7 @@ https://developer.atlassian.com/server/jira/platform/jira-rest-api-example-creat
 */
 func supportJiraFormats(v string, customDebug debug) (result interface{}, err error) {
 
-	valueSplit := strings.Split(v, "-")
+	valueSplit := strings.SplitN(v, "-", 3)
 
 	switch valueSplit[1] {
 	case JiraMultiSelect:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This config

```yaml
customMandatoryFields:
    customfield_10151:
      value: "jiraValue-MultiSelect-value with - hyphen"
```

produces this incorrect behaviour:

```
*** INFO *** Ticket data to be sent {"fields":{"customfield_10151":[{"value":"value with "}]...
...
*** INFO *** Details : {"error":"Option value 'value with ' is not valid"}
*** ERROR *** Request failed
```

This change means that the remainder of the string after the 2nd hyphen becomes the `value`

### Notes for the reviewer

I didn't add tests as:

- the whole `jiraValue` stuff looks untested atm so I would need to invest some time in it
- the change is simple

Please let me know if tests are required.

Thanks
