### PR TITLE
fix: add handling of double rest prefix in next pagination links

### DIFF
--- a/snyk_utils.go
+++ b/snyk_utils.go
@@ -221,7 +221,16 @@ func makeSnykAPIRequest_REST(verb string, baseURL string, endpointURL string, sn
 		if !next.IsValid {
 			url = ""
 		} else {
-			url = baseURL + next.Value
+			// Smart URL construction to prevent double /rest prefix
+			if strings.HasPrefix(next.Value, "/rest/") {
+				// If next.Value already has /rest prefix, extract base domain from baseURL
+				// and construct full URL to avoid double /rest
+				baseDomain := strings.TrimSuffix(baseURL, "/rest")
+				url = baseDomain + next.Value
+			} else {
+				// Normal case: next.Value doesn't have /rest prefix
+				url = baseURL + next.Value
+			}
 		}
 	}
 

--- a/snyk_utils_test.go
+++ b/snyk_utils_test.go
@@ -101,3 +101,21 @@ func TestRESTPaginationFunc(t *testing.T) {
 	comparison, _ := jsondiff.Compare(fixture, marshalledResp, &opts)
 	assert.Equal("FullMatch", comparison.String())
 }
+
+func TestRESTPaginationWithDoubleRestPrefix(t *testing.T) {
+	// Test the fix for preventing double /rest prefix in pagination URLs
+	assert := assert.New(t)
+	cD := debug{}
+	cD.setDebug(false)
+	server := HTTPResponseRestPaginationWithDoubleRest()
+
+	defer server.Close()
+
+	response, err := makeSnykAPIRequest_REST("GET", server.URL, "/rest/orgs/xyz-paging/projects?version=2024-10-15", "123", nil, cD)
+	if err != nil {
+		panic(err)
+	}
+
+	// Should have received data from both pages without errors
+	assert.Greater(len(response), 0, "Should have received paginated data")
+}


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Handles cases where the next link contains the /rest prefix during pagination.